### PR TITLE
Fix parsing of XTCE container sheet when no offset to parent is specifie...

### DIFF
--- a/yamcs-core/src/main/java/org/yamcs/xtce/SpreadsheetLoader.java
+++ b/yamcs-core/src/main/java/org/yamcs/xtce/SpreadsheetLoader.java
@@ -852,7 +852,7 @@ public class SpreadsheetLoader implements SpaceSystemLoader {
 				}
 				// after adding this measurement, we need to update the absoluteoffset for the next one. For this, we add the size of the current SequenceEntry to the absoluteoffset
 				int size=getSize(param,sc);
-				if ((repeated != -1) && (size != -1)) {
+				if ((repeated != -1) && (size != -1) && (absoluteoffset != -1)) {
 					absoluteoffset += repeated * size;
 				} else {
 					// from this moment on, absoluteoffset is set to -1, meaning that all subsequent SequenceEntries must be relative


### PR DESCRIPTION
...d

If no offset to the parent is specified all sequence entries of that
container should be relative to the previous entry. With the previous
logic only the first sequence entry would be relative, the
absoluteoffset variable would then reset to a low value leading to
wrong results from the second entry onwards (which would be wrongly
considered as being of type CONTAINER_START).
