### PR TITLE
Add XTCE UnitSet support when reading from spreadsheet

### DIFF
--- a/yamcs-core/src/main/java/org/yamcs/xtce/SpreadsheetLoader.java
+++ b/yamcs-core/src/main/java/org/yamcs/xtce/SpreadsheetLoader.java
@@ -11,12 +11,6 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
-
-import org.jboss.netty.handler.codec.string.StringEncoder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.yamcs.ConfigurationException;
-
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -27,37 +21,10 @@ import jxl.Sheet;
 import jxl.Workbook;
 import jxl.read.biff.BiffException;
 
-import org.yamcs.xtce.AlarmRanges;
-import org.yamcs.xtce.BaseDataType;
-import org.yamcs.xtce.BinaryDataEncoding;
-import org.yamcs.xtce.BinaryParameterType;
-import org.yamcs.xtce.Calibrator;
-import org.yamcs.xtce.Comparison;
-import org.yamcs.xtce.ComparisonList;
-import org.yamcs.xtce.ContainerEntry;
-import org.yamcs.xtce.DataEncoding;
-import org.yamcs.xtce.DynamicIntegerValue;
-import org.yamcs.xtce.EnumeratedParameterType;
-import org.yamcs.xtce.FixedIntegerValue;
-import org.yamcs.xtce.FloatDataEncoding;
-import org.yamcs.xtce.FloatParameterType;
-import org.yamcs.xtce.FloatRange;
-import org.yamcs.xtce.IntegerDataEncoding;
-import org.yamcs.xtce.IntegerParameterType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.yamcs.ConfigurationException;
 import org.yamcs.xtce.NameReference.ResolvedAction;
-import org.yamcs.xtce.NumericContextAlarm;
-import org.yamcs.xtce.Parameter;
-import org.yamcs.xtce.ParameterEntry;
-import org.yamcs.xtce.ParameterInstanceRef;
-import org.yamcs.xtce.ParameterType;
-import org.yamcs.xtce.PolynomialCalibrator;
-import org.yamcs.xtce.Repeat;
-import org.yamcs.xtce.SequenceContainer;
-import org.yamcs.xtce.SequenceEntry;
-import org.yamcs.xtce.SplineCalibrator;
-import org.yamcs.xtce.SplinePoint;
-import org.yamcs.xtce.StringDataEncoding;
-import org.yamcs.xtce.StringParameterType;
 import org.yamcs.xtce.NameReference.Type;
 import org.yamcs.xtce.SequenceEntry.ReferenceLocationType;
 import org.yamcs.xtce.xml.XtceAliasSet;
@@ -456,7 +423,14 @@ public class SpreadsheetLoader implements SpaceSystemLoader {
 			} else {
 				error("Parameters:"+(i+1)+": unknown parameter type " + engtype);
 			}
-		
+			
+			String units=null;
+			if(cells.length>IDX_PARAM_ENGUNIT) units = cells[IDX_PARAM_ENGUNIT].getContents();
+			if(!"".equals(units) && units != null && ptype instanceof BaseDataType) {
+				UnitType unitType = new UnitType(units);
+				((BaseDataType) ptype).addUnit(unitType);
+			}
+			
 			loadParameterLimits(ptype,cells);
 			
 			//calibrations

--- a/yamcs-xtce/src/main/java/org/yamcs/xtce/BaseDataType.java
+++ b/yamcs-xtce/src/main/java/org/yamcs/xtce/BaseDataType.java
@@ -1,16 +1,30 @@
 package org.yamcs.xtce;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public abstract class BaseDataType extends NameDescription {
 	private static final long serialVersionUID = 200805131551L;
+	List<UnitType> unitSet = new ArrayList<UnitType>();
 	DataEncoding encoding;
+	
 	BaseDataType(String name){
 		super(name);
 	}
+	
 	public DataEncoding getEncoding() {
 		return encoding;
 	}
 	
 	public void setEncoding(DataEncoding encoding) {
 	    this.encoding = encoding;
+	}
+	
+	public List<UnitType> getUnitSet() {
+	    return unitSet;
+	}
+	
+	public void addUnit(UnitType unit) {
+	    unitSet.add(unit);
 	}
 }

--- a/yamcs-xtce/src/main/java/org/yamcs/xtce/UnitType.java
+++ b/yamcs-xtce/src/main/java/org/yamcs/xtce/UnitType.java
@@ -1,0 +1,43 @@
+package org.yamcs.xtce;
+
+import java.io.Serializable;
+
+/**
+ * Used to hold the unit(s) plus possibly the exponent and factor for the units
+ */
+public class UnitType implements Serializable {
+    private static final long serialVersionUID = -2505869748092316015L;
+
+    String description;
+    double power = 1;
+    String factor = "1";
+
+    UnitType(String description) {
+        this.description = description;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+    
+    public double getPower() {
+        return power;
+    }
+    
+    public void setPower(double power) {
+        this.power = power;
+    }
+    
+    public String getFactor() {
+        return factor;
+    }
+    
+    public void setFactor(String factor) {
+        this.factor = factor;
+    }
+    
+    @Override
+    public String toString() {
+        return "desc: "+description+", power: "+power+", factor: "+factor;
+    }
+}


### PR DESCRIPTION
The XTCE standard allows zero or more UnitType instantiations,
combined into one UnitSet.

In the SpreadsheetLoader, we only support one UnitType
(as encoded in the "eng unit" column of the Parameters sheet)
