### PR TITLE
Slightly modify structure of replay requests

### DIFF
--- a/yamcs-api/src/main/java/org/yamcs/protobuf/Yamcs.java
+++ b/yamcs-api/src/main/java/org/yamcs/protobuf/Yamcs.java
@@ -8408,7 +8408,7 @@ public final class Yamcs {
     public boolean hasSpeed() { return hasSpeed; }
     public org.yamcs.protobuf.Yamcs.ReplaySpeed getSpeed() { return speed_; }
     
-    // repeated .org.yamcs.protobuf.ProtoDataType type = 5;
+    // repeated .org.yamcs.protobuf.ProtoDataType type = 5 [deprecated = true];
     public static final int TYPE_FIELD_NUMBER = 5;
     private java.util.List<org.yamcs.protobuf.Yamcs.ProtoDataType> type_ =
       java.util.Collections.emptyList();
@@ -8420,7 +8420,7 @@ public final class Yamcs {
       return type_.get(index);
     }
     
-    // repeated .org.yamcs.protobuf.NamedObjectId tmPacketFilter = 6;
+    // repeated .org.yamcs.protobuf.NamedObjectId tmPacketFilter = 6 [deprecated = true];
     public static final int TMPACKETFILTER_FIELD_NUMBER = 6;
     private java.util.List<org.yamcs.protobuf.Yamcs.NamedObjectId> tmPacketFilter_ =
       java.util.Collections.emptyList();
@@ -8432,7 +8432,7 @@ public final class Yamcs {
       return tmPacketFilter_.get(index);
     }
     
-    // repeated string ppGroupFilter = 7;
+    // repeated string ppGroupFilter = 7 [deprecated = true];
     public static final int PPGROUPFILTER_FIELD_NUMBER = 7;
     private java.util.List<java.lang.String> ppGroupFilter_ =
       java.util.Collections.emptyList();
@@ -8451,10 +8451,42 @@ public final class Yamcs {
     public boolean hasParameterRequest() { return hasParameterRequest; }
     public org.yamcs.protobuf.Yamcs.ParameterReplayRequest getParameterRequest() { return parameterRequest_; }
     
+    // optional .org.yamcs.protobuf.PacketReplayRequest packetRequest = 9;
+    public static final int PACKETREQUEST_FIELD_NUMBER = 9;
+    private boolean hasPacketRequest;
+    private org.yamcs.protobuf.Yamcs.PacketReplayRequest packetRequest_;
+    public boolean hasPacketRequest() { return hasPacketRequest; }
+    public org.yamcs.protobuf.Yamcs.PacketReplayRequest getPacketRequest() { return packetRequest_; }
+    
+    // optional .org.yamcs.protobuf.EventReplayRequest eventRequest = 10;
+    public static final int EVENTREQUEST_FIELD_NUMBER = 10;
+    private boolean hasEventRequest;
+    private org.yamcs.protobuf.Yamcs.EventReplayRequest eventRequest_;
+    public boolean hasEventRequest() { return hasEventRequest; }
+    public org.yamcs.protobuf.Yamcs.EventReplayRequest getEventRequest() { return eventRequest_; }
+    
+    // optional .org.yamcs.protobuf.CommandHistoryReplayRequest commandHistoryRequest = 11;
+    public static final int COMMANDHISTORYREQUEST_FIELD_NUMBER = 11;
+    private boolean hasCommandHistoryRequest;
+    private org.yamcs.protobuf.Yamcs.CommandHistoryReplayRequest commandHistoryRequest_;
+    public boolean hasCommandHistoryRequest() { return hasCommandHistoryRequest; }
+    public org.yamcs.protobuf.Yamcs.CommandHistoryReplayRequest getCommandHistoryRequest() { return commandHistoryRequest_; }
+    
+    // optional .org.yamcs.protobuf.PpReplayRequest ppRequest = 12;
+    public static final int PPREQUEST_FIELD_NUMBER = 12;
+    private boolean hasPpRequest;
+    private org.yamcs.protobuf.Yamcs.PpReplayRequest ppRequest_;
+    public boolean hasPpRequest() { return hasPpRequest; }
+    public org.yamcs.protobuf.Yamcs.PpReplayRequest getPpRequest() { return ppRequest_; }
+    
     private void initFields() {
       endAction_ = org.yamcs.protobuf.Yamcs.EndAction.QUIT;
       speed_ = org.yamcs.protobuf.Yamcs.ReplaySpeed.getDefaultInstance();
       parameterRequest_ = org.yamcs.protobuf.Yamcs.ParameterReplayRequest.getDefaultInstance();
+      packetRequest_ = org.yamcs.protobuf.Yamcs.PacketReplayRequest.getDefaultInstance();
+      eventRequest_ = org.yamcs.protobuf.Yamcs.EventReplayRequest.getDefaultInstance();
+      commandHistoryRequest_ = org.yamcs.protobuf.Yamcs.CommandHistoryReplayRequest.getDefaultInstance();
+      ppRequest_ = org.yamcs.protobuf.Yamcs.PpReplayRequest.getDefaultInstance();
     }
     public final boolean isInitialized() {
       if (hasSpeed()) {
@@ -8465,6 +8497,9 @@ public final class Yamcs {
       }
       if (hasParameterRequest()) {
         if (!getParameterRequest().isInitialized()) return false;
+      }
+      if (hasPacketRequest()) {
+        if (!getPacketRequest().isInitialized()) return false;
       }
       return true;
     }
@@ -8495,6 +8530,18 @@ public final class Yamcs {
       }
       if (hasParameterRequest()) {
         output.writeMessage(8, getParameterRequest());
+      }
+      if (hasPacketRequest()) {
+        output.writeMessage(9, getPacketRequest());
+      }
+      if (hasEventRequest()) {
+        output.writeMessage(10, getEventRequest());
+      }
+      if (hasCommandHistoryRequest()) {
+        output.writeMessage(11, getCommandHistoryRequest());
+      }
+      if (hasPpRequest()) {
+        output.writeMessage(12, getPpRequest());
       }
       getUnknownFields().writeTo(output);
     }
@@ -8546,6 +8593,22 @@ public final class Yamcs {
       if (hasParameterRequest()) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(8, getParameterRequest());
+      }
+      if (hasPacketRequest()) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(9, getPacketRequest());
+      }
+      if (hasEventRequest()) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(10, getEventRequest());
+      }
+      if (hasCommandHistoryRequest()) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(11, getCommandHistoryRequest());
+      }
+      if (hasPpRequest()) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(12, getPpRequest());
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSerializedSize = size;
@@ -8750,6 +8813,18 @@ public final class Yamcs {
         if (other.hasParameterRequest()) {
           mergeParameterRequest(other.getParameterRequest());
         }
+        if (other.hasPacketRequest()) {
+          mergePacketRequest(other.getPacketRequest());
+        }
+        if (other.hasEventRequest()) {
+          mergeEventRequest(other.getEventRequest());
+        }
+        if (other.hasCommandHistoryRequest()) {
+          mergeCommandHistoryRequest(other.getCommandHistoryRequest());
+        }
+        if (other.hasPpRequest()) {
+          mergePpRequest(other.getPpRequest());
+        }
         this.mergeUnknownFields(other.getUnknownFields());
         return this;
       }
@@ -8844,6 +8919,42 @@ public final class Yamcs {
               }
               input.readMessage(subBuilder, extensionRegistry);
               setParameterRequest(subBuilder.buildPartial());
+              break;
+            }
+            case 74: {
+              org.yamcs.protobuf.Yamcs.PacketReplayRequest.Builder subBuilder = org.yamcs.protobuf.Yamcs.PacketReplayRequest.newBuilder();
+              if (hasPacketRequest()) {
+                subBuilder.mergeFrom(getPacketRequest());
+              }
+              input.readMessage(subBuilder, extensionRegistry);
+              setPacketRequest(subBuilder.buildPartial());
+              break;
+            }
+            case 82: {
+              org.yamcs.protobuf.Yamcs.EventReplayRequest.Builder subBuilder = org.yamcs.protobuf.Yamcs.EventReplayRequest.newBuilder();
+              if (hasEventRequest()) {
+                subBuilder.mergeFrom(getEventRequest());
+              }
+              input.readMessage(subBuilder, extensionRegistry);
+              setEventRequest(subBuilder.buildPartial());
+              break;
+            }
+            case 90: {
+              org.yamcs.protobuf.Yamcs.CommandHistoryReplayRequest.Builder subBuilder = org.yamcs.protobuf.Yamcs.CommandHistoryReplayRequest.newBuilder();
+              if (hasCommandHistoryRequest()) {
+                subBuilder.mergeFrom(getCommandHistoryRequest());
+              }
+              input.readMessage(subBuilder, extensionRegistry);
+              setCommandHistoryRequest(subBuilder.buildPartial());
+              break;
+            }
+            case 98: {
+              org.yamcs.protobuf.Yamcs.PpReplayRequest.Builder subBuilder = org.yamcs.protobuf.Yamcs.PpReplayRequest.newBuilder();
+              if (hasPpRequest()) {
+                subBuilder.mergeFrom(getPpRequest());
+              }
+              input.readMessage(subBuilder, extensionRegistry);
+              setPpRequest(subBuilder.buildPartial());
               break;
             }
           }
@@ -8945,7 +9056,7 @@ public final class Yamcs {
         return this;
       }
       
-      // repeated .org.yamcs.protobuf.ProtoDataType type = 5;
+      // repeated .org.yamcs.protobuf.ProtoDataType type = 5 [deprecated = true];
       public java.util.List<org.yamcs.protobuf.Yamcs.ProtoDataType> getTypeList() {
         return java.util.Collections.unmodifiableList(result.type_);
       }
@@ -8985,7 +9096,7 @@ public final class Yamcs {
         return this;
       }
       
-      // repeated .org.yamcs.protobuf.NamedObjectId tmPacketFilter = 6;
+      // repeated .org.yamcs.protobuf.NamedObjectId tmPacketFilter = 6 [deprecated = true];
       public java.util.List<org.yamcs.protobuf.Yamcs.NamedObjectId> getTmPacketFilterList() {
         return java.util.Collections.unmodifiableList(result.tmPacketFilter_);
       }
@@ -9036,7 +9147,7 @@ public final class Yamcs {
         return this;
       }
       
-      // repeated string ppGroupFilter = 7;
+      // repeated string ppGroupFilter = 7 [deprecated = true];
       public java.util.List<java.lang.String> getPpGroupFilterList() {
         return java.util.Collections.unmodifiableList(result.ppGroupFilter_);
       }
@@ -9113,6 +9224,154 @@ public final class Yamcs {
         return this;
       }
       
+      // optional .org.yamcs.protobuf.PacketReplayRequest packetRequest = 9;
+      public boolean hasPacketRequest() {
+        return result.hasPacketRequest();
+      }
+      public org.yamcs.protobuf.Yamcs.PacketReplayRequest getPacketRequest() {
+        return result.getPacketRequest();
+      }
+      public Builder setPacketRequest(org.yamcs.protobuf.Yamcs.PacketReplayRequest value) {
+        if (value == null) {
+          throw new NullPointerException();
+        }
+        result.hasPacketRequest = true;
+        result.packetRequest_ = value;
+        return this;
+      }
+      public Builder setPacketRequest(org.yamcs.protobuf.Yamcs.PacketReplayRequest.Builder builderForValue) {
+        result.hasPacketRequest = true;
+        result.packetRequest_ = builderForValue.build();
+        return this;
+      }
+      public Builder mergePacketRequest(org.yamcs.protobuf.Yamcs.PacketReplayRequest value) {
+        if (result.hasPacketRequest() &&
+            result.packetRequest_ != org.yamcs.protobuf.Yamcs.PacketReplayRequest.getDefaultInstance()) {
+          result.packetRequest_ =
+            org.yamcs.protobuf.Yamcs.PacketReplayRequest.newBuilder(result.packetRequest_).mergeFrom(value).buildPartial();
+        } else {
+          result.packetRequest_ = value;
+        }
+        result.hasPacketRequest = true;
+        return this;
+      }
+      public Builder clearPacketRequest() {
+        result.hasPacketRequest = false;
+        result.packetRequest_ = org.yamcs.protobuf.Yamcs.PacketReplayRequest.getDefaultInstance();
+        return this;
+      }
+      
+      // optional .org.yamcs.protobuf.EventReplayRequest eventRequest = 10;
+      public boolean hasEventRequest() {
+        return result.hasEventRequest();
+      }
+      public org.yamcs.protobuf.Yamcs.EventReplayRequest getEventRequest() {
+        return result.getEventRequest();
+      }
+      public Builder setEventRequest(org.yamcs.protobuf.Yamcs.EventReplayRequest value) {
+        if (value == null) {
+          throw new NullPointerException();
+        }
+        result.hasEventRequest = true;
+        result.eventRequest_ = value;
+        return this;
+      }
+      public Builder setEventRequest(org.yamcs.protobuf.Yamcs.EventReplayRequest.Builder builderForValue) {
+        result.hasEventRequest = true;
+        result.eventRequest_ = builderForValue.build();
+        return this;
+      }
+      public Builder mergeEventRequest(org.yamcs.protobuf.Yamcs.EventReplayRequest value) {
+        if (result.hasEventRequest() &&
+            result.eventRequest_ != org.yamcs.protobuf.Yamcs.EventReplayRequest.getDefaultInstance()) {
+          result.eventRequest_ =
+            org.yamcs.protobuf.Yamcs.EventReplayRequest.newBuilder(result.eventRequest_).mergeFrom(value).buildPartial();
+        } else {
+          result.eventRequest_ = value;
+        }
+        result.hasEventRequest = true;
+        return this;
+      }
+      public Builder clearEventRequest() {
+        result.hasEventRequest = false;
+        result.eventRequest_ = org.yamcs.protobuf.Yamcs.EventReplayRequest.getDefaultInstance();
+        return this;
+      }
+      
+      // optional .org.yamcs.protobuf.CommandHistoryReplayRequest commandHistoryRequest = 11;
+      public boolean hasCommandHistoryRequest() {
+        return result.hasCommandHistoryRequest();
+      }
+      public org.yamcs.protobuf.Yamcs.CommandHistoryReplayRequest getCommandHistoryRequest() {
+        return result.getCommandHistoryRequest();
+      }
+      public Builder setCommandHistoryRequest(org.yamcs.protobuf.Yamcs.CommandHistoryReplayRequest value) {
+        if (value == null) {
+          throw new NullPointerException();
+        }
+        result.hasCommandHistoryRequest = true;
+        result.commandHistoryRequest_ = value;
+        return this;
+      }
+      public Builder setCommandHistoryRequest(org.yamcs.protobuf.Yamcs.CommandHistoryReplayRequest.Builder builderForValue) {
+        result.hasCommandHistoryRequest = true;
+        result.commandHistoryRequest_ = builderForValue.build();
+        return this;
+      }
+      public Builder mergeCommandHistoryRequest(org.yamcs.protobuf.Yamcs.CommandHistoryReplayRequest value) {
+        if (result.hasCommandHistoryRequest() &&
+            result.commandHistoryRequest_ != org.yamcs.protobuf.Yamcs.CommandHistoryReplayRequest.getDefaultInstance()) {
+          result.commandHistoryRequest_ =
+            org.yamcs.protobuf.Yamcs.CommandHistoryReplayRequest.newBuilder(result.commandHistoryRequest_).mergeFrom(value).buildPartial();
+        } else {
+          result.commandHistoryRequest_ = value;
+        }
+        result.hasCommandHistoryRequest = true;
+        return this;
+      }
+      public Builder clearCommandHistoryRequest() {
+        result.hasCommandHistoryRequest = false;
+        result.commandHistoryRequest_ = org.yamcs.protobuf.Yamcs.CommandHistoryReplayRequest.getDefaultInstance();
+        return this;
+      }
+      
+      // optional .org.yamcs.protobuf.PpReplayRequest ppRequest = 12;
+      public boolean hasPpRequest() {
+        return result.hasPpRequest();
+      }
+      public org.yamcs.protobuf.Yamcs.PpReplayRequest getPpRequest() {
+        return result.getPpRequest();
+      }
+      public Builder setPpRequest(org.yamcs.protobuf.Yamcs.PpReplayRequest value) {
+        if (value == null) {
+          throw new NullPointerException();
+        }
+        result.hasPpRequest = true;
+        result.ppRequest_ = value;
+        return this;
+      }
+      public Builder setPpRequest(org.yamcs.protobuf.Yamcs.PpReplayRequest.Builder builderForValue) {
+        result.hasPpRequest = true;
+        result.ppRequest_ = builderForValue.build();
+        return this;
+      }
+      public Builder mergePpRequest(org.yamcs.protobuf.Yamcs.PpReplayRequest value) {
+        if (result.hasPpRequest() &&
+            result.ppRequest_ != org.yamcs.protobuf.Yamcs.PpReplayRequest.getDefaultInstance()) {
+          result.ppRequest_ =
+            org.yamcs.protobuf.Yamcs.PpReplayRequest.newBuilder(result.ppRequest_).mergeFrom(value).buildPartial();
+        } else {
+          result.ppRequest_ = value;
+        }
+        result.hasPpRequest = true;
+        return this;
+      }
+      public Builder clearPpRequest() {
+        result.hasPpRequest = false;
+        result.ppRequest_ = org.yamcs.protobuf.Yamcs.PpReplayRequest.getDefaultInstance();
+        return this;
+      }
+      
       // @@protoc_insertion_point(builder_scope:org.yamcs.protobuf.ReplayRequest)
     }
     
@@ -9152,16 +9411,16 @@ public final class Yamcs {
       return org.yamcs.protobuf.Yamcs.internal_static_org_yamcs_protobuf_ParameterReplayRequest_fieldAccessorTable;
     }
     
-    // repeated .org.yamcs.protobuf.NamedObjectId parameter = 1;
-    public static final int PARAMETER_FIELD_NUMBER = 1;
-    private java.util.List<org.yamcs.protobuf.Yamcs.NamedObjectId> parameter_ =
+    // repeated .org.yamcs.protobuf.NamedObjectId nameFilter = 1;
+    public static final int NAMEFILTER_FIELD_NUMBER = 1;
+    private java.util.List<org.yamcs.protobuf.Yamcs.NamedObjectId> nameFilter_ =
       java.util.Collections.emptyList();
-    public java.util.List<org.yamcs.protobuf.Yamcs.NamedObjectId> getParameterList() {
-      return parameter_;
+    public java.util.List<org.yamcs.protobuf.Yamcs.NamedObjectId> getNameFilterList() {
+      return nameFilter_;
     }
-    public int getParameterCount() { return parameter_.size(); }
-    public org.yamcs.protobuf.Yamcs.NamedObjectId getParameter(int index) {
-      return parameter_.get(index);
+    public int getNameFilterCount() { return nameFilter_.size(); }
+    public org.yamcs.protobuf.Yamcs.NamedObjectId getNameFilter(int index) {
+      return nameFilter_.get(index);
     }
     
     // optional bool sendRaw = 2 [default = false];
@@ -9181,7 +9440,7 @@ public final class Yamcs {
     private void initFields() {
     }
     public final boolean isInitialized() {
-      for (org.yamcs.protobuf.Yamcs.NamedObjectId element : getParameterList()) {
+      for (org.yamcs.protobuf.Yamcs.NamedObjectId element : getNameFilterList()) {
         if (!element.isInitialized()) return false;
       }
       return true;
@@ -9190,7 +9449,7 @@ public final class Yamcs {
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       getSerializedSize();
-      for (org.yamcs.protobuf.Yamcs.NamedObjectId element : getParameterList()) {
+      for (org.yamcs.protobuf.Yamcs.NamedObjectId element : getNameFilterList()) {
         output.writeMessage(1, element);
       }
       if (hasSendRaw()) {
@@ -9208,7 +9467,7 @@ public final class Yamcs {
       if (size != -1) return size;
     
       size = 0;
-      for (org.yamcs.protobuf.Yamcs.NamedObjectId element : getParameterList()) {
+      for (org.yamcs.protobuf.Yamcs.NamedObjectId element : getNameFilterList()) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(1, element);
       }
@@ -9362,9 +9621,9 @@ public final class Yamcs {
           throw new IllegalStateException(
             "build() has already been called on this Builder.");
         }
-        if (result.parameter_ != java.util.Collections.EMPTY_LIST) {
-          result.parameter_ =
-            java.util.Collections.unmodifiableList(result.parameter_);
+        if (result.nameFilter_ != java.util.Collections.EMPTY_LIST) {
+          result.nameFilter_ =
+            java.util.Collections.unmodifiableList(result.nameFilter_);
         }
         org.yamcs.protobuf.Yamcs.ParameterReplayRequest returnMe = result;
         result = null;
@@ -9382,11 +9641,11 @@ public final class Yamcs {
       
       public Builder mergeFrom(org.yamcs.protobuf.Yamcs.ParameterReplayRequest other) {
         if (other == org.yamcs.protobuf.Yamcs.ParameterReplayRequest.getDefaultInstance()) return this;
-        if (!other.parameter_.isEmpty()) {
-          if (result.parameter_.isEmpty()) {
-            result.parameter_ = new java.util.ArrayList<org.yamcs.protobuf.Yamcs.NamedObjectId>();
+        if (!other.nameFilter_.isEmpty()) {
+          if (result.nameFilter_.isEmpty()) {
+            result.nameFilter_ = new java.util.ArrayList<org.yamcs.protobuf.Yamcs.NamedObjectId>();
           }
-          result.parameter_.addAll(other.parameter_);
+          result.nameFilter_.addAll(other.nameFilter_);
         }
         if (other.hasSendRaw()) {
           setSendRaw(other.getSendRaw());
@@ -9422,7 +9681,7 @@ public final class Yamcs {
             case 10: {
               org.yamcs.protobuf.Yamcs.NamedObjectId.Builder subBuilder = org.yamcs.protobuf.Yamcs.NamedObjectId.newBuilder();
               input.readMessage(subBuilder, extensionRegistry);
-              addParameter(subBuilder.buildPartial());
+              addNameFilter(subBuilder.buildPartial());
               break;
             }
             case 16: {
@@ -9438,54 +9697,54 @@ public final class Yamcs {
       }
       
       
-      // repeated .org.yamcs.protobuf.NamedObjectId parameter = 1;
-      public java.util.List<org.yamcs.protobuf.Yamcs.NamedObjectId> getParameterList() {
-        return java.util.Collections.unmodifiableList(result.parameter_);
+      // repeated .org.yamcs.protobuf.NamedObjectId nameFilter = 1;
+      public java.util.List<org.yamcs.protobuf.Yamcs.NamedObjectId> getNameFilterList() {
+        return java.util.Collections.unmodifiableList(result.nameFilter_);
       }
-      public int getParameterCount() {
-        return result.getParameterCount();
+      public int getNameFilterCount() {
+        return result.getNameFilterCount();
       }
-      public org.yamcs.protobuf.Yamcs.NamedObjectId getParameter(int index) {
-        return result.getParameter(index);
+      public org.yamcs.protobuf.Yamcs.NamedObjectId getNameFilter(int index) {
+        return result.getNameFilter(index);
       }
-      public Builder setParameter(int index, org.yamcs.protobuf.Yamcs.NamedObjectId value) {
+      public Builder setNameFilter(int index, org.yamcs.protobuf.Yamcs.NamedObjectId value) {
         if (value == null) {
           throw new NullPointerException();
         }
-        result.parameter_.set(index, value);
+        result.nameFilter_.set(index, value);
         return this;
       }
-      public Builder setParameter(int index, org.yamcs.protobuf.Yamcs.NamedObjectId.Builder builderForValue) {
-        result.parameter_.set(index, builderForValue.build());
+      public Builder setNameFilter(int index, org.yamcs.protobuf.Yamcs.NamedObjectId.Builder builderForValue) {
+        result.nameFilter_.set(index, builderForValue.build());
         return this;
       }
-      public Builder addParameter(org.yamcs.protobuf.Yamcs.NamedObjectId value) {
+      public Builder addNameFilter(org.yamcs.protobuf.Yamcs.NamedObjectId value) {
         if (value == null) {
           throw new NullPointerException();
         }
-        if (result.parameter_.isEmpty()) {
-          result.parameter_ = new java.util.ArrayList<org.yamcs.protobuf.Yamcs.NamedObjectId>();
+        if (result.nameFilter_.isEmpty()) {
+          result.nameFilter_ = new java.util.ArrayList<org.yamcs.protobuf.Yamcs.NamedObjectId>();
         }
-        result.parameter_.add(value);
+        result.nameFilter_.add(value);
         return this;
       }
-      public Builder addParameter(org.yamcs.protobuf.Yamcs.NamedObjectId.Builder builderForValue) {
-        if (result.parameter_.isEmpty()) {
-          result.parameter_ = new java.util.ArrayList<org.yamcs.protobuf.Yamcs.NamedObjectId>();
+      public Builder addNameFilter(org.yamcs.protobuf.Yamcs.NamedObjectId.Builder builderForValue) {
+        if (result.nameFilter_.isEmpty()) {
+          result.nameFilter_ = new java.util.ArrayList<org.yamcs.protobuf.Yamcs.NamedObjectId>();
         }
-        result.parameter_.add(builderForValue.build());
+        result.nameFilter_.add(builderForValue.build());
         return this;
       }
-      public Builder addAllParameter(
+      public Builder addAllNameFilter(
           java.lang.Iterable<? extends org.yamcs.protobuf.Yamcs.NamedObjectId> values) {
-        if (result.parameter_.isEmpty()) {
-          result.parameter_ = new java.util.ArrayList<org.yamcs.protobuf.Yamcs.NamedObjectId>();
+        if (result.nameFilter_.isEmpty()) {
+          result.nameFilter_ = new java.util.ArrayList<org.yamcs.protobuf.Yamcs.NamedObjectId>();
         }
-        super.addAll(values, result.parameter_);
+        super.addAll(values, result.nameFilter_);
         return this;
       }
-      public Builder clearParameter() {
-        result.parameter_ = java.util.Collections.emptyList();
+      public Builder clearNameFilter() {
+        result.nameFilter_ = java.util.Collections.emptyList();
         return this;
       }
       
@@ -9535,6 +9794,1153 @@ public final class Yamcs {
     }
     
     // @@protoc_insertion_point(class_scope:org.yamcs.protobuf.ParameterReplayRequest)
+  }
+  
+  public static final class PacketReplayRequest extends
+      com.google.protobuf.GeneratedMessage {
+    // Use PacketReplayRequest.newBuilder() to construct.
+    private PacketReplayRequest() {
+      initFields();
+    }
+    private PacketReplayRequest(boolean noInit) {}
+    
+    private static final PacketReplayRequest defaultInstance;
+    public static PacketReplayRequest getDefaultInstance() {
+      return defaultInstance;
+    }
+    
+    public PacketReplayRequest getDefaultInstanceForType() {
+      return defaultInstance;
+    }
+    
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return org.yamcs.protobuf.Yamcs.internal_static_org_yamcs_protobuf_PacketReplayRequest_descriptor;
+    }
+    
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return org.yamcs.protobuf.Yamcs.internal_static_org_yamcs_protobuf_PacketReplayRequest_fieldAccessorTable;
+    }
+    
+    // repeated .org.yamcs.protobuf.NamedObjectId nameFilter = 1;
+    public static final int NAMEFILTER_FIELD_NUMBER = 1;
+    private java.util.List<org.yamcs.protobuf.Yamcs.NamedObjectId> nameFilter_ =
+      java.util.Collections.emptyList();
+    public java.util.List<org.yamcs.protobuf.Yamcs.NamedObjectId> getNameFilterList() {
+      return nameFilter_;
+    }
+    public int getNameFilterCount() { return nameFilter_.size(); }
+    public org.yamcs.protobuf.Yamcs.NamedObjectId getNameFilter(int index) {
+      return nameFilter_.get(index);
+    }
+    
+    private void initFields() {
+    }
+    public final boolean isInitialized() {
+      for (org.yamcs.protobuf.Yamcs.NamedObjectId element : getNameFilterList()) {
+        if (!element.isInitialized()) return false;
+      }
+      return true;
+    }
+    
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      getSerializedSize();
+      for (org.yamcs.protobuf.Yamcs.NamedObjectId element : getNameFilterList()) {
+        output.writeMessage(1, element);
+      }
+      getUnknownFields().writeTo(output);
+    }
+    
+    private int memoizedSerializedSize = -1;
+    public int getSerializedSize() {
+      int size = memoizedSerializedSize;
+      if (size != -1) return size;
+    
+      size = 0;
+      for (org.yamcs.protobuf.Yamcs.NamedObjectId element : getNameFilterList()) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(1, element);
+      }
+      size += getUnknownFields().getSerializedSize();
+      memoizedSerializedSize = size;
+      return size;
+    }
+    
+    public static org.yamcs.protobuf.Yamcs.PacketReplayRequest parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return newBuilder().mergeFrom(data).buildParsed();
+    }
+    public static org.yamcs.protobuf.Yamcs.PacketReplayRequest parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return newBuilder().mergeFrom(data, extensionRegistry)
+               .buildParsed();
+    }
+    public static org.yamcs.protobuf.Yamcs.PacketReplayRequest parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return newBuilder().mergeFrom(data).buildParsed();
+    }
+    public static org.yamcs.protobuf.Yamcs.PacketReplayRequest parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return newBuilder().mergeFrom(data, extensionRegistry)
+               .buildParsed();
+    }
+    public static org.yamcs.protobuf.Yamcs.PacketReplayRequest parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return newBuilder().mergeFrom(input).buildParsed();
+    }
+    public static org.yamcs.protobuf.Yamcs.PacketReplayRequest parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return newBuilder().mergeFrom(input, extensionRegistry)
+               .buildParsed();
+    }
+    public static org.yamcs.protobuf.Yamcs.PacketReplayRequest parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      Builder builder = newBuilder();
+      if (builder.mergeDelimitedFrom(input)) {
+        return builder.buildParsed();
+      } else {
+        return null;
+      }
+    }
+    public static org.yamcs.protobuf.Yamcs.PacketReplayRequest parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      Builder builder = newBuilder();
+      if (builder.mergeDelimitedFrom(input, extensionRegistry)) {
+        return builder.buildParsed();
+      } else {
+        return null;
+      }
+    }
+    public static org.yamcs.protobuf.Yamcs.PacketReplayRequest parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return newBuilder().mergeFrom(input).buildParsed();
+    }
+    public static org.yamcs.protobuf.Yamcs.PacketReplayRequest parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return newBuilder().mergeFrom(input, extensionRegistry)
+               .buildParsed();
+    }
+    
+    public static Builder newBuilder() { return Builder.create(); }
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder(org.yamcs.protobuf.Yamcs.PacketReplayRequest prototype) {
+      return newBuilder().mergeFrom(prototype);
+    }
+    public Builder toBuilder() { return newBuilder(this); }
+    
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessage.Builder<Builder> {
+      private org.yamcs.protobuf.Yamcs.PacketReplayRequest result;
+      
+      // Construct using org.yamcs.protobuf.Yamcs.PacketReplayRequest.newBuilder()
+      private Builder() {}
+      
+      private static Builder create() {
+        Builder builder = new Builder();
+        builder.result = new org.yamcs.protobuf.Yamcs.PacketReplayRequest();
+        return builder;
+      }
+      
+      protected org.yamcs.protobuf.Yamcs.PacketReplayRequest internalGetResult() {
+        return result;
+      }
+      
+      public Builder clear() {
+        if (result == null) {
+          throw new IllegalStateException(
+            "Cannot call clear() after build().");
+        }
+        result = new org.yamcs.protobuf.Yamcs.PacketReplayRequest();
+        return this;
+      }
+      
+      public Builder clone() {
+        return create().mergeFrom(result);
+      }
+      
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return org.yamcs.protobuf.Yamcs.PacketReplayRequest.getDescriptor();
+      }
+      
+      public org.yamcs.protobuf.Yamcs.PacketReplayRequest getDefaultInstanceForType() {
+        return org.yamcs.protobuf.Yamcs.PacketReplayRequest.getDefaultInstance();
+      }
+      
+      public boolean isInitialized() {
+        return result.isInitialized();
+      }
+      public org.yamcs.protobuf.Yamcs.PacketReplayRequest build() {
+        if (result != null && !isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return buildPartial();
+      }
+      
+      private org.yamcs.protobuf.Yamcs.PacketReplayRequest buildParsed()
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        if (!isInitialized()) {
+          throw newUninitializedMessageException(
+            result).asInvalidProtocolBufferException();
+        }
+        return buildPartial();
+      }
+      
+      public org.yamcs.protobuf.Yamcs.PacketReplayRequest buildPartial() {
+        if (result == null) {
+          throw new IllegalStateException(
+            "build() has already been called on this Builder.");
+        }
+        if (result.nameFilter_ != java.util.Collections.EMPTY_LIST) {
+          result.nameFilter_ =
+            java.util.Collections.unmodifiableList(result.nameFilter_);
+        }
+        org.yamcs.protobuf.Yamcs.PacketReplayRequest returnMe = result;
+        result = null;
+        return returnMe;
+      }
+      
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof org.yamcs.protobuf.Yamcs.PacketReplayRequest) {
+          return mergeFrom((org.yamcs.protobuf.Yamcs.PacketReplayRequest)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+      
+      public Builder mergeFrom(org.yamcs.protobuf.Yamcs.PacketReplayRequest other) {
+        if (other == org.yamcs.protobuf.Yamcs.PacketReplayRequest.getDefaultInstance()) return this;
+        if (!other.nameFilter_.isEmpty()) {
+          if (result.nameFilter_.isEmpty()) {
+            result.nameFilter_ = new java.util.ArrayList<org.yamcs.protobuf.Yamcs.NamedObjectId>();
+          }
+          result.nameFilter_.addAll(other.nameFilter_);
+        }
+        this.mergeUnknownFields(other.getUnknownFields());
+        return this;
+      }
+      
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder(
+            this.getUnknownFields());
+        while (true) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              this.setUnknownFields(unknownFields.build());
+              return this;
+            default: {
+              if (!parseUnknownField(input, unknownFields,
+                                     extensionRegistry, tag)) {
+                this.setUnknownFields(unknownFields.build());
+                return this;
+              }
+              break;
+            }
+            case 10: {
+              org.yamcs.protobuf.Yamcs.NamedObjectId.Builder subBuilder = org.yamcs.protobuf.Yamcs.NamedObjectId.newBuilder();
+              input.readMessage(subBuilder, extensionRegistry);
+              addNameFilter(subBuilder.buildPartial());
+              break;
+            }
+          }
+        }
+      }
+      
+      
+      // repeated .org.yamcs.protobuf.NamedObjectId nameFilter = 1;
+      public java.util.List<org.yamcs.protobuf.Yamcs.NamedObjectId> getNameFilterList() {
+        return java.util.Collections.unmodifiableList(result.nameFilter_);
+      }
+      public int getNameFilterCount() {
+        return result.getNameFilterCount();
+      }
+      public org.yamcs.protobuf.Yamcs.NamedObjectId getNameFilter(int index) {
+        return result.getNameFilter(index);
+      }
+      public Builder setNameFilter(int index, org.yamcs.protobuf.Yamcs.NamedObjectId value) {
+        if (value == null) {
+          throw new NullPointerException();
+        }
+        result.nameFilter_.set(index, value);
+        return this;
+      }
+      public Builder setNameFilter(int index, org.yamcs.protobuf.Yamcs.NamedObjectId.Builder builderForValue) {
+        result.nameFilter_.set(index, builderForValue.build());
+        return this;
+      }
+      public Builder addNameFilter(org.yamcs.protobuf.Yamcs.NamedObjectId value) {
+        if (value == null) {
+          throw new NullPointerException();
+        }
+        if (result.nameFilter_.isEmpty()) {
+          result.nameFilter_ = new java.util.ArrayList<org.yamcs.protobuf.Yamcs.NamedObjectId>();
+        }
+        result.nameFilter_.add(value);
+        return this;
+      }
+      public Builder addNameFilter(org.yamcs.protobuf.Yamcs.NamedObjectId.Builder builderForValue) {
+        if (result.nameFilter_.isEmpty()) {
+          result.nameFilter_ = new java.util.ArrayList<org.yamcs.protobuf.Yamcs.NamedObjectId>();
+        }
+        result.nameFilter_.add(builderForValue.build());
+        return this;
+      }
+      public Builder addAllNameFilter(
+          java.lang.Iterable<? extends org.yamcs.protobuf.Yamcs.NamedObjectId> values) {
+        if (result.nameFilter_.isEmpty()) {
+          result.nameFilter_ = new java.util.ArrayList<org.yamcs.protobuf.Yamcs.NamedObjectId>();
+        }
+        super.addAll(values, result.nameFilter_);
+        return this;
+      }
+      public Builder clearNameFilter() {
+        result.nameFilter_ = java.util.Collections.emptyList();
+        return this;
+      }
+      
+      // @@protoc_insertion_point(builder_scope:org.yamcs.protobuf.PacketReplayRequest)
+    }
+    
+    static {
+      defaultInstance = new PacketReplayRequest(true);
+      org.yamcs.protobuf.Yamcs.internalForceInit();
+      defaultInstance.initFields();
+    }
+    
+    // @@protoc_insertion_point(class_scope:org.yamcs.protobuf.PacketReplayRequest)
+  }
+  
+  public static final class EventReplayRequest extends
+      com.google.protobuf.GeneratedMessage {
+    // Use EventReplayRequest.newBuilder() to construct.
+    private EventReplayRequest() {
+      initFields();
+    }
+    private EventReplayRequest(boolean noInit) {}
+    
+    private static final EventReplayRequest defaultInstance;
+    public static EventReplayRequest getDefaultInstance() {
+      return defaultInstance;
+    }
+    
+    public EventReplayRequest getDefaultInstanceForType() {
+      return defaultInstance;
+    }
+    
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return org.yamcs.protobuf.Yamcs.internal_static_org_yamcs_protobuf_EventReplayRequest_descriptor;
+    }
+    
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return org.yamcs.protobuf.Yamcs.internal_static_org_yamcs_protobuf_EventReplayRequest_fieldAccessorTable;
+    }
+    
+    private void initFields() {
+    }
+    public final boolean isInitialized() {
+      return true;
+    }
+    
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      getSerializedSize();
+      getUnknownFields().writeTo(output);
+    }
+    
+    private int memoizedSerializedSize = -1;
+    public int getSerializedSize() {
+      int size = memoizedSerializedSize;
+      if (size != -1) return size;
+    
+      size = 0;
+      size += getUnknownFields().getSerializedSize();
+      memoizedSerializedSize = size;
+      return size;
+    }
+    
+    public static org.yamcs.protobuf.Yamcs.EventReplayRequest parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return newBuilder().mergeFrom(data).buildParsed();
+    }
+    public static org.yamcs.protobuf.Yamcs.EventReplayRequest parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return newBuilder().mergeFrom(data, extensionRegistry)
+               .buildParsed();
+    }
+    public static org.yamcs.protobuf.Yamcs.EventReplayRequest parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return newBuilder().mergeFrom(data).buildParsed();
+    }
+    public static org.yamcs.protobuf.Yamcs.EventReplayRequest parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return newBuilder().mergeFrom(data, extensionRegistry)
+               .buildParsed();
+    }
+    public static org.yamcs.protobuf.Yamcs.EventReplayRequest parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return newBuilder().mergeFrom(input).buildParsed();
+    }
+    public static org.yamcs.protobuf.Yamcs.EventReplayRequest parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return newBuilder().mergeFrom(input, extensionRegistry)
+               .buildParsed();
+    }
+    public static org.yamcs.protobuf.Yamcs.EventReplayRequest parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      Builder builder = newBuilder();
+      if (builder.mergeDelimitedFrom(input)) {
+        return builder.buildParsed();
+      } else {
+        return null;
+      }
+    }
+    public static org.yamcs.protobuf.Yamcs.EventReplayRequest parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      Builder builder = newBuilder();
+      if (builder.mergeDelimitedFrom(input, extensionRegistry)) {
+        return builder.buildParsed();
+      } else {
+        return null;
+      }
+    }
+    public static org.yamcs.protobuf.Yamcs.EventReplayRequest parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return newBuilder().mergeFrom(input).buildParsed();
+    }
+    public static org.yamcs.protobuf.Yamcs.EventReplayRequest parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return newBuilder().mergeFrom(input, extensionRegistry)
+               .buildParsed();
+    }
+    
+    public static Builder newBuilder() { return Builder.create(); }
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder(org.yamcs.protobuf.Yamcs.EventReplayRequest prototype) {
+      return newBuilder().mergeFrom(prototype);
+    }
+    public Builder toBuilder() { return newBuilder(this); }
+    
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessage.Builder<Builder> {
+      private org.yamcs.protobuf.Yamcs.EventReplayRequest result;
+      
+      // Construct using org.yamcs.protobuf.Yamcs.EventReplayRequest.newBuilder()
+      private Builder() {}
+      
+      private static Builder create() {
+        Builder builder = new Builder();
+        builder.result = new org.yamcs.protobuf.Yamcs.EventReplayRequest();
+        return builder;
+      }
+      
+      protected org.yamcs.protobuf.Yamcs.EventReplayRequest internalGetResult() {
+        return result;
+      }
+      
+      public Builder clear() {
+        if (result == null) {
+          throw new IllegalStateException(
+            "Cannot call clear() after build().");
+        }
+        result = new org.yamcs.protobuf.Yamcs.EventReplayRequest();
+        return this;
+      }
+      
+      public Builder clone() {
+        return create().mergeFrom(result);
+      }
+      
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return org.yamcs.protobuf.Yamcs.EventReplayRequest.getDescriptor();
+      }
+      
+      public org.yamcs.protobuf.Yamcs.EventReplayRequest getDefaultInstanceForType() {
+        return org.yamcs.protobuf.Yamcs.EventReplayRequest.getDefaultInstance();
+      }
+      
+      public boolean isInitialized() {
+        return result.isInitialized();
+      }
+      public org.yamcs.protobuf.Yamcs.EventReplayRequest build() {
+        if (result != null && !isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return buildPartial();
+      }
+      
+      private org.yamcs.protobuf.Yamcs.EventReplayRequest buildParsed()
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        if (!isInitialized()) {
+          throw newUninitializedMessageException(
+            result).asInvalidProtocolBufferException();
+        }
+        return buildPartial();
+      }
+      
+      public org.yamcs.protobuf.Yamcs.EventReplayRequest buildPartial() {
+        if (result == null) {
+          throw new IllegalStateException(
+            "build() has already been called on this Builder.");
+        }
+        org.yamcs.protobuf.Yamcs.EventReplayRequest returnMe = result;
+        result = null;
+        return returnMe;
+      }
+      
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof org.yamcs.protobuf.Yamcs.EventReplayRequest) {
+          return mergeFrom((org.yamcs.protobuf.Yamcs.EventReplayRequest)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+      
+      public Builder mergeFrom(org.yamcs.protobuf.Yamcs.EventReplayRequest other) {
+        if (other == org.yamcs.protobuf.Yamcs.EventReplayRequest.getDefaultInstance()) return this;
+        this.mergeUnknownFields(other.getUnknownFields());
+        return this;
+      }
+      
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder(
+            this.getUnknownFields());
+        while (true) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              this.setUnknownFields(unknownFields.build());
+              return this;
+            default: {
+              if (!parseUnknownField(input, unknownFields,
+                                     extensionRegistry, tag)) {
+                this.setUnknownFields(unknownFields.build());
+                return this;
+              }
+              break;
+            }
+          }
+        }
+      }
+      
+      
+      // @@protoc_insertion_point(builder_scope:org.yamcs.protobuf.EventReplayRequest)
+    }
+    
+    static {
+      defaultInstance = new EventReplayRequest(true);
+      org.yamcs.protobuf.Yamcs.internalForceInit();
+      defaultInstance.initFields();
+    }
+    
+    // @@protoc_insertion_point(class_scope:org.yamcs.protobuf.EventReplayRequest)
+  }
+  
+  public static final class CommandHistoryReplayRequest extends
+      com.google.protobuf.GeneratedMessage {
+    // Use CommandHistoryReplayRequest.newBuilder() to construct.
+    private CommandHistoryReplayRequest() {
+      initFields();
+    }
+    private CommandHistoryReplayRequest(boolean noInit) {}
+    
+    private static final CommandHistoryReplayRequest defaultInstance;
+    public static CommandHistoryReplayRequest getDefaultInstance() {
+      return defaultInstance;
+    }
+    
+    public CommandHistoryReplayRequest getDefaultInstanceForType() {
+      return defaultInstance;
+    }
+    
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return org.yamcs.protobuf.Yamcs.internal_static_org_yamcs_protobuf_CommandHistoryReplayRequest_descriptor;
+    }
+    
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return org.yamcs.protobuf.Yamcs.internal_static_org_yamcs_protobuf_CommandHistoryReplayRequest_fieldAccessorTable;
+    }
+    
+    private void initFields() {
+    }
+    public final boolean isInitialized() {
+      return true;
+    }
+    
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      getSerializedSize();
+      getUnknownFields().writeTo(output);
+    }
+    
+    private int memoizedSerializedSize = -1;
+    public int getSerializedSize() {
+      int size = memoizedSerializedSize;
+      if (size != -1) return size;
+    
+      size = 0;
+      size += getUnknownFields().getSerializedSize();
+      memoizedSerializedSize = size;
+      return size;
+    }
+    
+    public static org.yamcs.protobuf.Yamcs.CommandHistoryReplayRequest parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return newBuilder().mergeFrom(data).buildParsed();
+    }
+    public static org.yamcs.protobuf.Yamcs.CommandHistoryReplayRequest parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return newBuilder().mergeFrom(data, extensionRegistry)
+               .buildParsed();
+    }
+    public static org.yamcs.protobuf.Yamcs.CommandHistoryReplayRequest parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return newBuilder().mergeFrom(data).buildParsed();
+    }
+    public static org.yamcs.protobuf.Yamcs.CommandHistoryReplayRequest parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return newBuilder().mergeFrom(data, extensionRegistry)
+               .buildParsed();
+    }
+    public static org.yamcs.protobuf.Yamcs.CommandHistoryReplayRequest parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return newBuilder().mergeFrom(input).buildParsed();
+    }
+    public static org.yamcs.protobuf.Yamcs.CommandHistoryReplayRequest parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return newBuilder().mergeFrom(input, extensionRegistry)
+               .buildParsed();
+    }
+    public static org.yamcs.protobuf.Yamcs.CommandHistoryReplayRequest parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      Builder builder = newBuilder();
+      if (builder.mergeDelimitedFrom(input)) {
+        return builder.buildParsed();
+      } else {
+        return null;
+      }
+    }
+    public static org.yamcs.protobuf.Yamcs.CommandHistoryReplayRequest parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      Builder builder = newBuilder();
+      if (builder.mergeDelimitedFrom(input, extensionRegistry)) {
+        return builder.buildParsed();
+      } else {
+        return null;
+      }
+    }
+    public static org.yamcs.protobuf.Yamcs.CommandHistoryReplayRequest parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return newBuilder().mergeFrom(input).buildParsed();
+    }
+    public static org.yamcs.protobuf.Yamcs.CommandHistoryReplayRequest parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return newBuilder().mergeFrom(input, extensionRegistry)
+               .buildParsed();
+    }
+    
+    public static Builder newBuilder() { return Builder.create(); }
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder(org.yamcs.protobuf.Yamcs.CommandHistoryReplayRequest prototype) {
+      return newBuilder().mergeFrom(prototype);
+    }
+    public Builder toBuilder() { return newBuilder(this); }
+    
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessage.Builder<Builder> {
+      private org.yamcs.protobuf.Yamcs.CommandHistoryReplayRequest result;
+      
+      // Construct using org.yamcs.protobuf.Yamcs.CommandHistoryReplayRequest.newBuilder()
+      private Builder() {}
+      
+      private static Builder create() {
+        Builder builder = new Builder();
+        builder.result = new org.yamcs.protobuf.Yamcs.CommandHistoryReplayRequest();
+        return builder;
+      }
+      
+      protected org.yamcs.protobuf.Yamcs.CommandHistoryReplayRequest internalGetResult() {
+        return result;
+      }
+      
+      public Builder clear() {
+        if (result == null) {
+          throw new IllegalStateException(
+            "Cannot call clear() after build().");
+        }
+        result = new org.yamcs.protobuf.Yamcs.CommandHistoryReplayRequest();
+        return this;
+      }
+      
+      public Builder clone() {
+        return create().mergeFrom(result);
+      }
+      
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return org.yamcs.protobuf.Yamcs.CommandHistoryReplayRequest.getDescriptor();
+      }
+      
+      public org.yamcs.protobuf.Yamcs.CommandHistoryReplayRequest getDefaultInstanceForType() {
+        return org.yamcs.protobuf.Yamcs.CommandHistoryReplayRequest.getDefaultInstance();
+      }
+      
+      public boolean isInitialized() {
+        return result.isInitialized();
+      }
+      public org.yamcs.protobuf.Yamcs.CommandHistoryReplayRequest build() {
+        if (result != null && !isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return buildPartial();
+      }
+      
+      private org.yamcs.protobuf.Yamcs.CommandHistoryReplayRequest buildParsed()
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        if (!isInitialized()) {
+          throw newUninitializedMessageException(
+            result).asInvalidProtocolBufferException();
+        }
+        return buildPartial();
+      }
+      
+      public org.yamcs.protobuf.Yamcs.CommandHistoryReplayRequest buildPartial() {
+        if (result == null) {
+          throw new IllegalStateException(
+            "build() has already been called on this Builder.");
+        }
+        org.yamcs.protobuf.Yamcs.CommandHistoryReplayRequest returnMe = result;
+        result = null;
+        return returnMe;
+      }
+      
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof org.yamcs.protobuf.Yamcs.CommandHistoryReplayRequest) {
+          return mergeFrom((org.yamcs.protobuf.Yamcs.CommandHistoryReplayRequest)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+      
+      public Builder mergeFrom(org.yamcs.protobuf.Yamcs.CommandHistoryReplayRequest other) {
+        if (other == org.yamcs.protobuf.Yamcs.CommandHistoryReplayRequest.getDefaultInstance()) return this;
+        this.mergeUnknownFields(other.getUnknownFields());
+        return this;
+      }
+      
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder(
+            this.getUnknownFields());
+        while (true) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              this.setUnknownFields(unknownFields.build());
+              return this;
+            default: {
+              if (!parseUnknownField(input, unknownFields,
+                                     extensionRegistry, tag)) {
+                this.setUnknownFields(unknownFields.build());
+                return this;
+              }
+              break;
+            }
+          }
+        }
+      }
+      
+      
+      // @@protoc_insertion_point(builder_scope:org.yamcs.protobuf.CommandHistoryReplayRequest)
+    }
+    
+    static {
+      defaultInstance = new CommandHistoryReplayRequest(true);
+      org.yamcs.protobuf.Yamcs.internalForceInit();
+      defaultInstance.initFields();
+    }
+    
+    // @@protoc_insertion_point(class_scope:org.yamcs.protobuf.CommandHistoryReplayRequest)
+  }
+  
+  public static final class PpReplayRequest extends
+      com.google.protobuf.GeneratedMessage {
+    // Use PpReplayRequest.newBuilder() to construct.
+    private PpReplayRequest() {
+      initFields();
+    }
+    private PpReplayRequest(boolean noInit) {}
+    
+    private static final PpReplayRequest defaultInstance;
+    public static PpReplayRequest getDefaultInstance() {
+      return defaultInstance;
+    }
+    
+    public PpReplayRequest getDefaultInstanceForType() {
+      return defaultInstance;
+    }
+    
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return org.yamcs.protobuf.Yamcs.internal_static_org_yamcs_protobuf_PpReplayRequest_descriptor;
+    }
+    
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return org.yamcs.protobuf.Yamcs.internal_static_org_yamcs_protobuf_PpReplayRequest_fieldAccessorTable;
+    }
+    
+    // repeated string groupNameFilter = 1;
+    public static final int GROUPNAMEFILTER_FIELD_NUMBER = 1;
+    private java.util.List<java.lang.String> groupNameFilter_ =
+      java.util.Collections.emptyList();
+    public java.util.List<java.lang.String> getGroupNameFilterList() {
+      return groupNameFilter_;
+    }
+    public int getGroupNameFilterCount() { return groupNameFilter_.size(); }
+    public java.lang.String getGroupNameFilter(int index) {
+      return groupNameFilter_.get(index);
+    }
+    
+    private void initFields() {
+    }
+    public final boolean isInitialized() {
+      return true;
+    }
+    
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      getSerializedSize();
+      for (java.lang.String element : getGroupNameFilterList()) {
+        output.writeString(1, element);
+      }
+      getUnknownFields().writeTo(output);
+    }
+    
+    private int memoizedSerializedSize = -1;
+    public int getSerializedSize() {
+      int size = memoizedSerializedSize;
+      if (size != -1) return size;
+    
+      size = 0;
+      {
+        int dataSize = 0;
+        for (java.lang.String element : getGroupNameFilterList()) {
+          dataSize += com.google.protobuf.CodedOutputStream
+            .computeStringSizeNoTag(element);
+        }
+        size += dataSize;
+        size += 1 * getGroupNameFilterList().size();
+      }
+      size += getUnknownFields().getSerializedSize();
+      memoizedSerializedSize = size;
+      return size;
+    }
+    
+    public static org.yamcs.protobuf.Yamcs.PpReplayRequest parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return newBuilder().mergeFrom(data).buildParsed();
+    }
+    public static org.yamcs.protobuf.Yamcs.PpReplayRequest parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return newBuilder().mergeFrom(data, extensionRegistry)
+               .buildParsed();
+    }
+    public static org.yamcs.protobuf.Yamcs.PpReplayRequest parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return newBuilder().mergeFrom(data).buildParsed();
+    }
+    public static org.yamcs.protobuf.Yamcs.PpReplayRequest parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return newBuilder().mergeFrom(data, extensionRegistry)
+               .buildParsed();
+    }
+    public static org.yamcs.protobuf.Yamcs.PpReplayRequest parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return newBuilder().mergeFrom(input).buildParsed();
+    }
+    public static org.yamcs.protobuf.Yamcs.PpReplayRequest parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return newBuilder().mergeFrom(input, extensionRegistry)
+               .buildParsed();
+    }
+    public static org.yamcs.protobuf.Yamcs.PpReplayRequest parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      Builder builder = newBuilder();
+      if (builder.mergeDelimitedFrom(input)) {
+        return builder.buildParsed();
+      } else {
+        return null;
+      }
+    }
+    public static org.yamcs.protobuf.Yamcs.PpReplayRequest parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      Builder builder = newBuilder();
+      if (builder.mergeDelimitedFrom(input, extensionRegistry)) {
+        return builder.buildParsed();
+      } else {
+        return null;
+      }
+    }
+    public static org.yamcs.protobuf.Yamcs.PpReplayRequest parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return newBuilder().mergeFrom(input).buildParsed();
+    }
+    public static org.yamcs.protobuf.Yamcs.PpReplayRequest parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return newBuilder().mergeFrom(input, extensionRegistry)
+               .buildParsed();
+    }
+    
+    public static Builder newBuilder() { return Builder.create(); }
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder(org.yamcs.protobuf.Yamcs.PpReplayRequest prototype) {
+      return newBuilder().mergeFrom(prototype);
+    }
+    public Builder toBuilder() { return newBuilder(this); }
+    
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessage.Builder<Builder> {
+      private org.yamcs.protobuf.Yamcs.PpReplayRequest result;
+      
+      // Construct using org.yamcs.protobuf.Yamcs.PpReplayRequest.newBuilder()
+      private Builder() {}
+      
+      private static Builder create() {
+        Builder builder = new Builder();
+        builder.result = new org.yamcs.protobuf.Yamcs.PpReplayRequest();
+        return builder;
+      }
+      
+      protected org.yamcs.protobuf.Yamcs.PpReplayRequest internalGetResult() {
+        return result;
+      }
+      
+      public Builder clear() {
+        if (result == null) {
+          throw new IllegalStateException(
+            "Cannot call clear() after build().");
+        }
+        result = new org.yamcs.protobuf.Yamcs.PpReplayRequest();
+        return this;
+      }
+      
+      public Builder clone() {
+        return create().mergeFrom(result);
+      }
+      
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return org.yamcs.protobuf.Yamcs.PpReplayRequest.getDescriptor();
+      }
+      
+      public org.yamcs.protobuf.Yamcs.PpReplayRequest getDefaultInstanceForType() {
+        return org.yamcs.protobuf.Yamcs.PpReplayRequest.getDefaultInstance();
+      }
+      
+      public boolean isInitialized() {
+        return result.isInitialized();
+      }
+      public org.yamcs.protobuf.Yamcs.PpReplayRequest build() {
+        if (result != null && !isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return buildPartial();
+      }
+      
+      private org.yamcs.protobuf.Yamcs.PpReplayRequest buildParsed()
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        if (!isInitialized()) {
+          throw newUninitializedMessageException(
+            result).asInvalidProtocolBufferException();
+        }
+        return buildPartial();
+      }
+      
+      public org.yamcs.protobuf.Yamcs.PpReplayRequest buildPartial() {
+        if (result == null) {
+          throw new IllegalStateException(
+            "build() has already been called on this Builder.");
+        }
+        if (result.groupNameFilter_ != java.util.Collections.EMPTY_LIST) {
+          result.groupNameFilter_ =
+            java.util.Collections.unmodifiableList(result.groupNameFilter_);
+        }
+        org.yamcs.protobuf.Yamcs.PpReplayRequest returnMe = result;
+        result = null;
+        return returnMe;
+      }
+      
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof org.yamcs.protobuf.Yamcs.PpReplayRequest) {
+          return mergeFrom((org.yamcs.protobuf.Yamcs.PpReplayRequest)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+      
+      public Builder mergeFrom(org.yamcs.protobuf.Yamcs.PpReplayRequest other) {
+        if (other == org.yamcs.protobuf.Yamcs.PpReplayRequest.getDefaultInstance()) return this;
+        if (!other.groupNameFilter_.isEmpty()) {
+          if (result.groupNameFilter_.isEmpty()) {
+            result.groupNameFilter_ = new java.util.ArrayList<java.lang.String>();
+          }
+          result.groupNameFilter_.addAll(other.groupNameFilter_);
+        }
+        this.mergeUnknownFields(other.getUnknownFields());
+        return this;
+      }
+      
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder(
+            this.getUnknownFields());
+        while (true) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              this.setUnknownFields(unknownFields.build());
+              return this;
+            default: {
+              if (!parseUnknownField(input, unknownFields,
+                                     extensionRegistry, tag)) {
+                this.setUnknownFields(unknownFields.build());
+                return this;
+              }
+              break;
+            }
+            case 10: {
+              addGroupNameFilter(input.readString());
+              break;
+            }
+          }
+        }
+      }
+      
+      
+      // repeated string groupNameFilter = 1;
+      public java.util.List<java.lang.String> getGroupNameFilterList() {
+        return java.util.Collections.unmodifiableList(result.groupNameFilter_);
+      }
+      public int getGroupNameFilterCount() {
+        return result.getGroupNameFilterCount();
+      }
+      public java.lang.String getGroupNameFilter(int index) {
+        return result.getGroupNameFilter(index);
+      }
+      public Builder setGroupNameFilter(int index, java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  result.groupNameFilter_.set(index, value);
+        return this;
+      }
+      public Builder addGroupNameFilter(java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  if (result.groupNameFilter_.isEmpty()) {
+          result.groupNameFilter_ = new java.util.ArrayList<java.lang.String>();
+        }
+        result.groupNameFilter_.add(value);
+        return this;
+      }
+      public Builder addAllGroupNameFilter(
+          java.lang.Iterable<? extends java.lang.String> values) {
+        if (result.groupNameFilter_.isEmpty()) {
+          result.groupNameFilter_ = new java.util.ArrayList<java.lang.String>();
+        }
+        super.addAll(values, result.groupNameFilter_);
+        return this;
+      }
+      public Builder clearGroupNameFilter() {
+        result.groupNameFilter_ = java.util.Collections.emptyList();
+        return this;
+      }
+      
+      // @@protoc_insertion_point(builder_scope:org.yamcs.protobuf.PpReplayRequest)
+    }
+    
+    static {
+      defaultInstance = new PpReplayRequest(true);
+      org.yamcs.protobuf.Yamcs.internalForceInit();
+      defaultInstance.initFields();
+    }
+    
+    // @@protoc_insertion_point(class_scope:org.yamcs.protobuf.PpReplayRequest)
   }
   
   public static final class ReplayStatus extends
@@ -12262,6 +13668,26 @@ public final class Yamcs {
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_org_yamcs_protobuf_ParameterReplayRequest_fieldAccessorTable;
   private static com.google.protobuf.Descriptors.Descriptor
+    internal_static_org_yamcs_protobuf_PacketReplayRequest_descriptor;
+  private static
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      internal_static_org_yamcs_protobuf_PacketReplayRequest_fieldAccessorTable;
+  private static com.google.protobuf.Descriptors.Descriptor
+    internal_static_org_yamcs_protobuf_EventReplayRequest_descriptor;
+  private static
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      internal_static_org_yamcs_protobuf_EventReplayRequest_fieldAccessorTable;
+  private static com.google.protobuf.Descriptors.Descriptor
+    internal_static_org_yamcs_protobuf_CommandHistoryReplayRequest_descriptor;
+  private static
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      internal_static_org_yamcs_protobuf_CommandHistoryReplayRequest_fieldAccessorTable;
+  private static com.google.protobuf.Descriptors.Descriptor
+    internal_static_org_yamcs_protobuf_PpReplayRequest_descriptor;
+  private static
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      internal_static_org_yamcs_protobuf_PpReplayRequest_fieldAccessorTable;
+  private static com.google.protobuf.Descriptors.Descriptor
     internal_static_org_yamcs_protobuf_ReplayStatus_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
@@ -12338,62 +13764,73 @@ public final class Yamcs {
       "Tag\"?\n\020DeleteTagRequest\022+\n\003tag\030\003 \002(\0132\036.o" +
       "rg.yamcs.protobuf.ArchiveTag\"O\n\013ReplaySp" +
       "eed\0221\n\004type\030\001 \002(\0162#.org.yamcs.protobuf.R" +
-      "eplaySpeedType\022\r\n\005param\030\002 \001(\002\"\335\002\n\rReplay" +
+      "eplaySpeedType\022\r\n\005param\030\002 \001(\002\"\357\004\n\rReplay" +
       "Request\022\r\n\005start\030\001 \001(\003\022\014\n\004stop\030\002 \001(\003\0226\n\t" +
       "endAction\030\003 \001(\0162\035.org.yamcs.protobuf.End" +
       "Action:\004QUIT\022.\n\005speed\030\004 \001(\0132\037.org.yamcs." +
-      "protobuf.ReplaySpeed\022/\n\004type\030\005 \003(\0162!.org" +
-      ".yamcs.protobuf.ProtoDataType\0229\n\016tmPacke" +
-      "tFilter\030\006 \003(\0132!.org.yamcs.protobuf.Named",
-      "ObjectId\022\025\n\rppGroupFilter\030\007 \003(\t\022D\n\020param" +
-      "eterRequest\030\010 \001(\0132*.org.yamcs.protobuf.P" +
-      "arameterReplayRequest\"\210\001\n\026ParameterRepla" +
-      "yRequest\0224\n\tparameter\030\001 \003(\0132!.org.yamcs." +
-      "protobuf.NamedObjectId\022\026\n\007sendRaw\030\002 \001(\010:" +
-      "\005false\022 \n\021performMonitoring\030\003 \001(\010:\005false" +
-      "\"\365\001\n\014ReplayStatus\022;\n\005state\030\001 \002(\0162,.org.y" +
-      "amcs.protobuf.ReplayStatus.ReplayState\0222" +
-      "\n\007request\030\002 \001(\0132!.org.yamcs.protobuf.Rep" +
-      "layRequest\022\024\n\014errorMessage\030\003 \001(\t\"^\n\013Repl",
-      "ayState\022\022\n\016INITIALIZATION\020\000\022\013\n\007RUNNING\020\001" +
-      "\022\013\n\007STOPPED\020\002\022\t\n\005ERROR\020\003\022\n\n\006PAUSED\020\004\022\n\n\006" +
-      "CLOSED\020\005\"e\n\014TmPacketData\022\025\n\rreceptionTim" +
-      "e\030\001 \002(\003\022\016\n\006packet\030\002 \002(\014\022\026\n\016generationTim" +
-      "e\030\003 \001(\003\022\026\n\016sequenceNumber\030\004 \001(\005\"\354\001\n\005Even" +
-      "t\022\016\n\006source\030\001 \002(\t\022\026\n\016generationTime\030\002 \002(" +
-      "\003\022\025\n\rreceptionTime\030\003 \002(\003\022\021\n\tseqNumber\030\004 " +
-      "\002(\005\022\014\n\004type\030\005 \001(\t\022\017\n\007message\030\006 \002(\t\022?\n\010se" +
-      "verity\030\007 \001(\0162\'.org.yamcs.protobuf.Event." +
-      "EventSeverity:\004INFO\"1\n\rEventSeverity\022\010\n\004",
-      "INFO\020\000\022\013\n\007WARNING\020\001\022\t\n\005ERROR\020\002*)\n\tEndAct" +
-      "ion\022\010\n\004LOOP\020\001\022\010\n\004QUIT\020\002\022\010\n\004STOP\020\003*:\n\017Rep" +
-      "laySpeedType\022\010\n\004AFAP\020\001\022\017\n\013FIXED_DELAY\020\002\022" +
-      "\014\n\010REALTIME\020\003*\225\001\n\rProtoDataType\022\014\n\010DT_ER" +
-      "ROR\020\001\022\020\n\014STATE_CHANGE\020\002\022\r\n\tTM_PACKET\020\003\022\006" +
-      "\n\002PP\020\004\022\t\n\005EVENT\020\005\022\021\n\rARCHIVE_INDEX\020\006\022\017\n\013" +
-      "ARCHIVE_TAG\020\007\022\r\n\tPARAMETER\020\010\022\017\n\013CMD_HIST" +
-      "ORY\020\t2\275\001\n\014YamcsControl\022Q\n\021GetYamcsInstan" +
-      "ces\022\030.org.yamcs.protobuf.Void\032\".org.yamc" +
-      "s.protobuf.YamcsInstances\022Z\n\022GetMissionD",
-      "atabase\022*.org.yamcs.protobuf.MissionData" +
-      "baseRequest\032\030.org.yamcs.protobuf.Void2\307\002" +
-      "\n\030RealtimeParameterService\022J\n\tSubscribe\022" +
-      "#.org.yamcs.protobuf.NamedObjectList\032\030.o" +
-      "rg.yamcs.protobuf.Void\022K\n\014SubscribeAll\022!" +
-      ".org.yamcs.protobuf.StringMessage\032\030.org." +
-      "yamcs.protobuf.Void\022L\n\013Unsubscribe\022#.org" +
-      ".yamcs.protobuf.NamedObjectList\032\030.org.ya" +
-      "mcs.protobuf.Void\022D\n\016UnsubscribeAll\022\030.or" +
-      "g.yamcs.protobuf.Void\032\030.org.yamcs.protob",
-      "uf.Void2\310\002\n\014ArchiveIndex\022M\n\010GetIndex\022 .o" +
-      "rg.yamcs.protobuf.IndexRequest\032\037.org.yam" +
-      "cs.protobuf.IndexResult\022I\n\006GetTag\022 .org." +
-      "yamcs.protobuf.IndexRequest\032\035.org.yamcs." +
-      "protobuf.TagResult\022Q\n\tUpsertTag\022$.org.ya" +
-      "mcs.protobuf.UpsertTagRequest\032\036.org.yamc" +
-      "s.protobuf.ArchiveTag\022K\n\tDeleteTag\022$.org" +
-      ".yamcs.protobuf.DeleteTagRequest\032\030.org.y" +
-      "amcs.protobuf.Void"
+      "protobuf.ReplaySpeed\0223\n\004type\030\005 \003(\0162!.org" +
+      ".yamcs.protobuf.ProtoDataTypeB\002\030\001\022=\n\016tmP" +
+      "acketFilter\030\006 \003(\0132!.org.yamcs.protobuf.N",
+      "amedObjectIdB\002\030\001\022\031\n\rppGroupFilter\030\007 \003(\tB" +
+      "\002\030\001\022D\n\020parameterRequest\030\010 \001(\0132*.org.yamc" +
+      "s.protobuf.ParameterReplayRequest\022>\n\rpac" +
+      "ketRequest\030\t \001(\0132\'.org.yamcs.protobuf.Pa" +
+      "cketReplayRequest\022<\n\014eventRequest\030\n \001(\0132" +
+      "&.org.yamcs.protobuf.EventReplayRequest\022" +
+      "N\n\025commandHistoryRequest\030\013 \001(\0132/.org.yam" +
+      "cs.protobuf.CommandHistoryReplayRequest\022" +
+      "6\n\tppRequest\030\014 \001(\0132#.org.yamcs.protobuf." +
+      "PpReplayRequest\"\211\001\n\026ParameterReplayReque",
+      "st\0225\n\nnameFilter\030\001 \003(\0132!.org.yamcs.proto" +
+      "buf.NamedObjectId\022\026\n\007sendRaw\030\002 \001(\010:\005fals" +
+      "e\022 \n\021performMonitoring\030\003 \001(\010:\005false\"L\n\023P" +
+      "acketReplayRequest\0225\n\nnameFilter\030\001 \003(\0132!" +
+      ".org.yamcs.protobuf.NamedObjectId\"\024\n\022Eve" +
+      "ntReplayRequest\"\035\n\033CommandHistoryReplayR" +
+      "equest\"*\n\017PpReplayRequest\022\027\n\017groupNameFi" +
+      "lter\030\001 \003(\t\"\365\001\n\014ReplayStatus\022;\n\005state\030\001 \002" +
+      "(\0162,.org.yamcs.protobuf.ReplayStatus.Rep" +
+      "layState\0222\n\007request\030\002 \001(\0132!.org.yamcs.pr",
+      "otobuf.ReplayRequest\022\024\n\014errorMessage\030\003 \001" +
+      "(\t\"^\n\013ReplayState\022\022\n\016INITIALIZATION\020\000\022\013\n" +
+      "\007RUNNING\020\001\022\013\n\007STOPPED\020\002\022\t\n\005ERROR\020\003\022\n\n\006PA" +
+      "USED\020\004\022\n\n\006CLOSED\020\005\"e\n\014TmPacketData\022\025\n\rre" +
+      "ceptionTime\030\001 \002(\003\022\016\n\006packet\030\002 \002(\014\022\026\n\016gen" +
+      "erationTime\030\003 \001(\003\022\026\n\016sequenceNumber\030\004 \001(" +
+      "\005\"\354\001\n\005Event\022\016\n\006source\030\001 \002(\t\022\026\n\016generatio" +
+      "nTime\030\002 \002(\003\022\025\n\rreceptionTime\030\003 \002(\003\022\021\n\tse" +
+      "qNumber\030\004 \002(\005\022\014\n\004type\030\005 \001(\t\022\017\n\007message\030\006" +
+      " \002(\t\022?\n\010severity\030\007 \001(\0162\'.org.yamcs.proto",
+      "buf.Event.EventSeverity:\004INFO\"1\n\rEventSe" +
+      "verity\022\010\n\004INFO\020\000\022\013\n\007WARNING\020\001\022\t\n\005ERROR\020\002" +
+      "*)\n\tEndAction\022\010\n\004LOOP\020\001\022\010\n\004QUIT\020\002\022\010\n\004STO" +
+      "P\020\003*:\n\017ReplaySpeedType\022\010\n\004AFAP\020\001\022\017\n\013FIXE" +
+      "D_DELAY\020\002\022\014\n\010REALTIME\020\003*\225\001\n\rProtoDataTyp" +
+      "e\022\014\n\010DT_ERROR\020\001\022\020\n\014STATE_CHANGE\020\002\022\r\n\tTM_" +
+      "PACKET\020\003\022\006\n\002PP\020\004\022\t\n\005EVENT\020\005\022\021\n\rARCHIVE_I" +
+      "NDEX\020\006\022\017\n\013ARCHIVE_TAG\020\007\022\r\n\tPARAMETER\020\010\022\017" +
+      "\n\013CMD_HISTORY\020\t2\275\001\n\014YamcsControl\022Q\n\021GetY" +
+      "amcsInstances\022\030.org.yamcs.protobuf.Void\032",
+      "\".org.yamcs.protobuf.YamcsInstances\022Z\n\022G" +
+      "etMissionDatabase\022*.org.yamcs.protobuf.M" +
+      "issionDatabaseRequest\032\030.org.yamcs.protob" +
+      "uf.Void2\307\002\n\030RealtimeParameterService\022J\n\t" +
+      "Subscribe\022#.org.yamcs.protobuf.NamedObje" +
+      "ctList\032\030.org.yamcs.protobuf.Void\022K\n\014Subs" +
+      "cribeAll\022!.org.yamcs.protobuf.StringMess" +
+      "age\032\030.org.yamcs.protobuf.Void\022L\n\013Unsubsc" +
+      "ribe\022#.org.yamcs.protobuf.NamedObjectLis" +
+      "t\032\030.org.yamcs.protobuf.Void\022D\n\016Unsubscri",
+      "beAll\022\030.org.yamcs.protobuf.Void\032\030.org.ya" +
+      "mcs.protobuf.Void2\310\002\n\014ArchiveIndex\022M\n\010Ge" +
+      "tIndex\022 .org.yamcs.protobuf.IndexRequest" +
+      "\032\037.org.yamcs.protobuf.IndexResult\022I\n\006Get" +
+      "Tag\022 .org.yamcs.protobuf.IndexRequest\032\035." +
+      "org.yamcs.protobuf.TagResult\022Q\n\tUpsertTa" +
+      "g\022$.org.yamcs.protobuf.UpsertTagRequest\032" +
+      "\036.org.yamcs.protobuf.ArchiveTag\022K\n\tDelet" +
+      "eTag\022$.org.yamcs.protobuf.DeleteTagReque" +
+      "st\032\030.org.yamcs.protobuf.Void"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
       new com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner() {
@@ -12565,7 +14002,7 @@ public final class Yamcs {
           internal_static_org_yamcs_protobuf_ReplayRequest_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_org_yamcs_protobuf_ReplayRequest_descriptor,
-              new java.lang.String[] { "Start", "Stop", "EndAction", "Speed", "Type", "TmPacketFilter", "PpGroupFilter", "ParameterRequest", },
+              new java.lang.String[] { "Start", "Stop", "EndAction", "Speed", "Type", "TmPacketFilter", "PpGroupFilter", "ParameterRequest", "PacketRequest", "EventRequest", "CommandHistoryRequest", "PpRequest", },
               org.yamcs.protobuf.Yamcs.ReplayRequest.class,
               org.yamcs.protobuf.Yamcs.ReplayRequest.Builder.class);
           internal_static_org_yamcs_protobuf_ParameterReplayRequest_descriptor =
@@ -12573,11 +14010,43 @@ public final class Yamcs {
           internal_static_org_yamcs_protobuf_ParameterReplayRequest_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_org_yamcs_protobuf_ParameterReplayRequest_descriptor,
-              new java.lang.String[] { "Parameter", "SendRaw", "PerformMonitoring", },
+              new java.lang.String[] { "NameFilter", "SendRaw", "PerformMonitoring", },
               org.yamcs.protobuf.Yamcs.ParameterReplayRequest.class,
               org.yamcs.protobuf.Yamcs.ParameterReplayRequest.Builder.class);
-          internal_static_org_yamcs_protobuf_ReplayStatus_descriptor =
+          internal_static_org_yamcs_protobuf_PacketReplayRequest_descriptor =
             getDescriptor().getMessageTypes().get(22);
+          internal_static_org_yamcs_protobuf_PacketReplayRequest_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_org_yamcs_protobuf_PacketReplayRequest_descriptor,
+              new java.lang.String[] { "NameFilter", },
+              org.yamcs.protobuf.Yamcs.PacketReplayRequest.class,
+              org.yamcs.protobuf.Yamcs.PacketReplayRequest.Builder.class);
+          internal_static_org_yamcs_protobuf_EventReplayRequest_descriptor =
+            getDescriptor().getMessageTypes().get(23);
+          internal_static_org_yamcs_protobuf_EventReplayRequest_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_org_yamcs_protobuf_EventReplayRequest_descriptor,
+              new java.lang.String[] { },
+              org.yamcs.protobuf.Yamcs.EventReplayRequest.class,
+              org.yamcs.protobuf.Yamcs.EventReplayRequest.Builder.class);
+          internal_static_org_yamcs_protobuf_CommandHistoryReplayRequest_descriptor =
+            getDescriptor().getMessageTypes().get(24);
+          internal_static_org_yamcs_protobuf_CommandHistoryReplayRequest_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_org_yamcs_protobuf_CommandHistoryReplayRequest_descriptor,
+              new java.lang.String[] { },
+              org.yamcs.protobuf.Yamcs.CommandHistoryReplayRequest.class,
+              org.yamcs.protobuf.Yamcs.CommandHistoryReplayRequest.Builder.class);
+          internal_static_org_yamcs_protobuf_PpReplayRequest_descriptor =
+            getDescriptor().getMessageTypes().get(25);
+          internal_static_org_yamcs_protobuf_PpReplayRequest_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_org_yamcs_protobuf_PpReplayRequest_descriptor,
+              new java.lang.String[] { "GroupNameFilter", },
+              org.yamcs.protobuf.Yamcs.PpReplayRequest.class,
+              org.yamcs.protobuf.Yamcs.PpReplayRequest.Builder.class);
+          internal_static_org_yamcs_protobuf_ReplayStatus_descriptor =
+            getDescriptor().getMessageTypes().get(26);
           internal_static_org_yamcs_protobuf_ReplayStatus_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_org_yamcs_protobuf_ReplayStatus_descriptor,
@@ -12585,7 +14054,7 @@ public final class Yamcs {
               org.yamcs.protobuf.Yamcs.ReplayStatus.class,
               org.yamcs.protobuf.Yamcs.ReplayStatus.Builder.class);
           internal_static_org_yamcs_protobuf_TmPacketData_descriptor =
-            getDescriptor().getMessageTypes().get(23);
+            getDescriptor().getMessageTypes().get(27);
           internal_static_org_yamcs_protobuf_TmPacketData_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_org_yamcs_protobuf_TmPacketData_descriptor,
@@ -12593,7 +14062,7 @@ public final class Yamcs {
               org.yamcs.protobuf.Yamcs.TmPacketData.class,
               org.yamcs.protobuf.Yamcs.TmPacketData.Builder.class);
           internal_static_org_yamcs_protobuf_Event_descriptor =
-            getDescriptor().getMessageTypes().get(24);
+            getDescriptor().getMessageTypes().get(28);
           internal_static_org_yamcs_protobuf_Event_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_org_yamcs_protobuf_Event_descriptor,

--- a/yamcs-api/src/main/yamcs.proto
+++ b/yamcs-api/src/main/yamcs.proto
@@ -225,7 +225,7 @@ enum ProtoDataType {
        CMD_HISTORY=9;
 };
 
-//used to reply (concurrently) TM packets, parameters and events
+//used to replay (concurrently) TM packets, parameters and events
 message ReplayRequest {
     //time specification
     optional int64 start=1;
@@ -239,24 +239,42 @@ message ReplayRequest {
     
     //what data to be replayed
     //if PP is requested, the ParameterData message will be used but the data type will be PP
-    repeated ProtoDataType type=5; 
+    repeated ProtoDataType type=5[deprecated=true];
 
     //if type contains TM_PACKET, this can be used to restrict the packets replayed; if this is empty, all are sent)
-    repeated NamedObjectId tmPacketFilter=6;
+    repeated NamedObjectId tmPacketFilter=6[deprecated=true];
 
     //if type contains PP, this can be used to restrict the pp groups replayed; if this is empty, all are sent
-    repeated string ppGroupFilter=7; 
+    repeated string ppGroupFilter=7[deprecated=true];
 
-
+    // At least one of the following request types should be added
     optional ParameterReplayRequest parameterRequest=8;
+    optional PacketReplayRequest packetRequest=9;
+    optional EventReplayRequest eventRequest=10;
+    optional CommandHistoryReplayRequest commandHistoryRequest=11;
+    optional PpReplayRequest ppRequest=12;
 }
 
 message ParameterReplayRequest {
-    repeated NamedObjectId parameter=1;
+    repeated NamedObjectId nameFilter=1; // At least 1 filter is required
     optional bool sendRaw=2[default=false];
     optional bool performMonitoring=3[default=false]; //i.e. out of limit checking
 }
 
+message PacketReplayRequest {
+    // No filter, means all packets for which privileges exist, are sent
+    repeated NamedObjectId nameFilter=1;
+}
+
+message EventReplayRequest {
+}
+
+message CommandHistoryReplayRequest {
+}
+
+message PpReplayRequest {
+    repeated string groupNameFilter=1; // At least 1 filter is required
+}
 
 message ReplayStatus {
      enum ReplayState {

--- a/yamcs-core/src/main/java/org/yamcs/Privilege.java
+++ b/yamcs-core/src/main/java/org/yamcs/Privilege.java
@@ -1,6 +1,8 @@
 package org.yamcs;
 
+import java.security.cert.X509Certificate;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashSet;
@@ -12,18 +14,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.FutureTask;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.yamcs.ConfigurationException;
-import org.yamcs.api.YamcsSession;
-import org.yamcs.usoctools.XtceUtil;
-import org.yamcs.xtce.SequenceContainer;
-import org.yamcs.xtce.XtceDb;
-import org.yamcs.xtceproc.XtceDbFactory;
-
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.Arrays;
 
 import javax.naming.Context;
 import javax.naming.NamingEnumeration;
@@ -33,7 +25,13 @@ import javax.naming.directory.InitialDirContext;
 import javax.naming.directory.SearchControls;
 import javax.naming.directory.SearchResult;
 
-import java.security.cert.X509Certificate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.yamcs.api.YamcsSession;
+import org.yamcs.usoctools.XtceUtil;
+import org.yamcs.xtce.MdbMappings;
+import org.yamcs.xtce.XtceDb;
+import org.yamcs.xtceproc.XtceDbFactory;
 
 
 /**
@@ -213,7 +211,7 @@ public abstract class Privilege {
 	 */
 	public Collection<String> getTmPacketNames(String yamcsInstance, String namespace) throws ConfigurationException {
 		if( namespace == null ) {
-			namespace = "MDB:OPS Name";
+			namespace = MdbMappings.MDB_OPSNAME;
 		}
 		Collection<String> tl=XtceUtil.getInstance(XtceDbFactory.getInstance(yamcsInstance)).getTmPacketNames( namespace );
 		ArrayList<String> l=new ArrayList<String>();
@@ -235,7 +233,7 @@ public abstract class Privilege {
 	 */
 	public Collection<String> getTmParameterNames(String yamcsInstance, String namespace) throws ConfigurationException {
 		if( namespace == null ) {
-			namespace = "MDB:OPS Name";
+			namespace = MdbMappings.MDB_OPSNAME;
 		}
 		XtceDb xtcedb = XtceDbFactory.getInstance(yamcsInstance);
 		ArrayList<String> l=new ArrayList<String>();

--- a/yamcs-core/src/main/java/org/yamcs/archive/ParameterReplayHandler.java
+++ b/yamcs-core/src/main/java/org/yamcs/archive/ParameterReplayHandler.java
@@ -7,6 +7,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.yamcs.Channel;
@@ -20,25 +21,24 @@ import org.yamcs.ParameterValue;
 import org.yamcs.ParameterValueWithId;
 import org.yamcs.ProcessedParameterDefinition;
 import org.yamcs.TmProcessor;
+import org.yamcs.YamcsException;
 import org.yamcs.ppdb.PpDefDb;
+import org.yamcs.protobuf.Pvalue.ParameterData;
+import org.yamcs.protobuf.Yamcs.NamedObjectId;
+import org.yamcs.protobuf.Yamcs.NamedObjectList;
+import org.yamcs.protobuf.Yamcs.ProtoDataType;
+import org.yamcs.protobuf.Yamcs.ReplayRequest;
 import org.yamcs.tctm.AbstractTcTmService;
 import org.yamcs.tctm.TmPacketProvider;
-import org.yamcs.utils.CcsdsPacket;
+import org.yamcs.xtce.Parameter;
+import org.yamcs.xtce.SequenceContainer;
+import org.yamcs.xtce.XtceDb;
 import org.yamcs.xtceproc.Subscription;
 import org.yamcs.xtceproc.XtceTmProcessor;
 import org.yamcs.yarch.Tuple;
 
 import com.google.common.util.concurrent.AbstractService;
 import com.google.protobuf.MessageLite;
-import org.yamcs.YamcsException;
-import org.yamcs.protobuf.Pvalue.ParameterData;
-import org.yamcs.protobuf.Yamcs.NamedObjectId;
-import org.yamcs.protobuf.Yamcs.NamedObjectList;
-import org.yamcs.protobuf.Yamcs.ProtoDataType;
-import org.yamcs.protobuf.Yamcs.ReplayRequest;
-import org.yamcs.xtce.Parameter;
-import org.yamcs.xtce.SequenceContainer;
-import org.yamcs.xtce.XtceDb;
 
 public class ParameterReplayHandler implements ReplayHandler, ParameterConsumer {
     final XtceDb xtcedb;
@@ -77,7 +77,7 @@ public class ParameterReplayHandler implements ReplayHandler, ParameterConsumer 
         tmPartitions.clear();
 
         //find all the packets where a given parameter appears
-        List<NamedObjectId> plist=request.getParameterRequest().getParameterList();
+        List<NamedObjectId> plist=request.getParameterRequest().getNameFilterList();
         if(plist.isEmpty()) throw new YamcsException("Cannot create a replay with an empty parameter list");
 
         MyTcTmService tctms=new MyTcTmService();
@@ -150,7 +150,7 @@ public class ParameterReplayHandler implements ReplayHandler, ParameterConsumer 
                 else sb.append(", ");
                 sb.append("'").append(pn).append("'");
             }
-            sb.append(")");
+            sb.append(") and ");
 
             XtceTmReplayHandler.appendTimeClause(sb, request);
         }
@@ -165,7 +165,7 @@ public class ParameterReplayHandler implements ReplayHandler, ParameterConsumer 
                 else sb.append(", ");
                 sb.append("'").append(g).append("'");
             }
-            sb.append(")");
+            sb.append(") and ");
             XtceTmReplayHandler.appendTimeClause(sb, request);
         }
         if(hasTm && hasPp) sb.append(") USING gentime");

--- a/yamcs-core/src/main/java/org/yamcs/archive/PpReplayHandler.java
+++ b/yamcs-core/src/main/java/org/yamcs/archive/PpReplayHandler.java
@@ -6,21 +6,20 @@ import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.yamcs.ppdb.PpDefDb;
-import org.yamcs.yarch.Tuple;
-
-import com.google.protobuf.MessageLite;
-
 import org.yamcs.protobuf.Pvalue.ParameterData;
 import org.yamcs.protobuf.Pvalue.ParameterValue;
 import org.yamcs.protobuf.Yamcs.NamedObjectId;
 import org.yamcs.protobuf.Yamcs.ProtoDataType;
 import org.yamcs.protobuf.Yamcs.ReplayRequest;
+import org.yamcs.yarch.Tuple;
+
+import com.google.protobuf.MessageLite;
 
 public class PpReplayHandler implements ReplayHandler {
     Set<String>currentGroups=new HashSet<String>();
     final PpDefDb ppdb;
     ReplayRequest request;
-    final static Logger log=LoggerFactory.getLogger(PpReplayHandler.class.getName());
+    final static Logger log=LoggerFactory.getLogger(PpReplayHandler.class);
     
     public PpReplayHandler(PpDefDb ppdb) {
         this.ppdb=ppdb;
@@ -30,7 +29,8 @@ public class PpReplayHandler implements ReplayHandler {
     public void setRequest(ReplayRequest newRequest) {
         this.request=newRequest;
         currentGroups.clear();
-        currentGroups.addAll(newRequest.getPpGroupFilterList());
+        currentGroups.addAll(newRequest.getPpGroupFilterList()); // TODO delete once no longer deprecated
+        currentGroups.addAll(newRequest.getPpRequest().getGroupNameFilterList());
     }
 
     @Override
@@ -50,7 +50,7 @@ public class PpReplayHandler implements ReplayHandler {
             else sb.append(", ");
             sb.append("'").append(g).append("'");
         }
-        sb.append(")");
+        sb.append(") and ");
         XtceTmReplayHandler.appendTimeClause(sb, request);
         return sb.toString();
     }
@@ -78,7 +78,5 @@ public class PpReplayHandler implements ReplayHandler {
 
     @Override
     public void reset() {
-        // TODO Auto-generated method stub
-        
     }
 }

--- a/yamcs-core/src/main/java/org/yamcs/archive/TmReplayHandler.java
+++ b/yamcs-core/src/main/java/org/yamcs/archive/TmReplayHandler.java
@@ -2,18 +2,19 @@ package org.yamcs.archive;
 
 import java.util.HashSet;
 import java.util.Set;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.yamcs.usoctools.XtceUtil;
-import org.yamcs.yarch.Tuple;
-
-import com.google.protobuf.ByteString;
-import com.google.protobuf.MessageLite;
 import org.yamcs.YamcsException;
 import org.yamcs.protobuf.Yamcs.NamedObjectId;
 import org.yamcs.protobuf.Yamcs.ProtoDataType;
 import org.yamcs.protobuf.Yamcs.ReplayRequest;
 import org.yamcs.protobuf.Yamcs.TmPacketData;
+import org.yamcs.usoctools.XtceUtil;
+import org.yamcs.yarch.Tuple;
+
+import com.google.protobuf.ByteString;
+import com.google.protobuf.MessageLite;
 
 public class TmReplayHandler implements ReplayHandler {
     Set<String> partitions=new HashSet<String>();
@@ -31,20 +32,28 @@ public class TmReplayHandler implements ReplayHandler {
     public void setRequest(ReplayRequest newRequest) throws YamcsException{
         this.request=newRequest;
         partitions.clear();
+        // TODO OLD API, delete this for once deprecated API no longer in use
         for(NamedObjectId pnoi:newRequest.getTmPacketFilterList()) {
-            Integer packetId;
-            if(pnoi.hasNamespace()) {
-                packetId=xtceutil.getPacketId(pnoi.getName(),pnoi.getNamespace());
-            } else {
-                packetId=xtceutil.getPacketId(pnoi.getName());
-            }
-            if(packetId==null) {
-                log.warn("cannot find packetid for "+pnoi);
-                throw new YamcsException("cannot find packetid for "+pnoi);
-            }
-            String part=Integer.toHexString(packetId);
-            partitions.add(part);
+            addPartition(pnoi);
         }
+        for(NamedObjectId pnoi:newRequest.getPacketRequest().getNameFilterList()) {
+            addPartition(pnoi);
+        }
+    }
+    
+    private void addPartition(NamedObjectId pnoi) throws YamcsException {
+        Integer packetId;
+        if(pnoi.hasNamespace()) {
+            packetId=xtceutil.getPacketId(pnoi.getName(),pnoi.getNamespace());
+        } else {
+            packetId=xtceutil.getPacketId(pnoi.getName());
+        }
+        if(packetId==null) {
+            log.warn("cannot find packetid for "+pnoi);
+            throw new YamcsException("cannot find packetid for "+pnoi);
+        }
+        String part=Integer.toHexString(packetId);
+        partitions.add(part);        
     }
 
     @Override

--- a/yamcs-core/src/main/java/org/yamcs/ui/CommandHistoryRetrievalGui.java
+++ b/yamcs-core/src/main/java/org/yamcs/ui/CommandHistoryRetrievalGui.java
@@ -29,20 +29,20 @@ import org.hornetq.api.core.HornetQException;
 import org.hornetq.api.core.SimpleString;
 import org.hornetq.api.core.client.ClientMessage;
 import org.hornetq.api.core.client.MessageHandler;
-
 import org.yamcs.api.ConnectionParameters;
 import org.yamcs.api.Protocol;
 import org.yamcs.api.YamcsApiException;
 import org.yamcs.api.YamcsClient;
 import org.yamcs.api.YamcsConnectData;
 import org.yamcs.api.YamcsSession;
-import org.yamcs.utils.CommandHistoryFormatter;
-import org.yamcs.utils.TimeEncoding;
 import org.yamcs.protobuf.Commanding.CommandHistoryEntry;
+import org.yamcs.protobuf.Yamcs.CommandHistoryReplayRequest;
 import org.yamcs.protobuf.Yamcs.EndAction;
 import org.yamcs.protobuf.Yamcs.ProtoDataType;
 import org.yamcs.protobuf.Yamcs.ReplayRequest;
 import org.yamcs.protobuf.Yamcs.StringMessage;
+import org.yamcs.utils.CommandHistoryFormatter;
+import org.yamcs.utils.TimeEncoding;
 
 
 /**
@@ -142,8 +142,9 @@ public class CommandHistoryRetrievalGui extends JFrame implements MessageHandler
 			    ycd.instance=archiveInstance;
 			    ysession=YamcsSession.newBuilder().setConnectionParams(ycd).build();
 			    yclient=ysession.newClientBuilder().setRpc(true).setDataConsumer(null, null).build();
-			    ReplayRequest.Builder rr=ReplayRequest.newBuilder().setEndAction(EndAction.QUIT).addType(ProtoDataType.CMD_HISTORY)
-                    .setStart(startInstant).setStop(stopInstant);
+			    CommandHistoryReplayRequest chr = CommandHistoryReplayRequest.newBuilder().build();
+			    ReplayRequest.Builder rr=ReplayRequest.newBuilder().setEndAction(EndAction.QUIT)
+                    .setStart(startInstant).setStop(stopInstant).setCommandHistoryRequest(chr);
                
 			    StringMessage answer=(StringMessage) yclient.executeRpc(Protocol.getYarchReplayControlAddress(ycd.instance), "createReplay", rr.build(), StringMessage.newBuilder());
 			    SimpleString replayAddress=new SimpleString(answer.getMessage());

--- a/yamcs-core/src/main/java/org/yamcs/ui/PacketRetrievalGui.java
+++ b/yamcs-core/src/main/java/org/yamcs/ui/PacketRetrievalGui.java
@@ -35,24 +35,24 @@ import org.hornetq.api.core.SimpleString;
 import org.hornetq.api.core.client.ClientMessage;
 import org.hornetq.api.core.client.MessageHandler;
 import org.yamcs.YamcsException;
-import org.yamcs.xtce.MdbMappings;
-
 import org.yamcs.api.ConnectionParameters;
 import org.yamcs.api.Protocol;
 import org.yamcs.api.YamcsApiException;
 import org.yamcs.api.YamcsClient;
 import org.yamcs.api.YamcsConnectData;
 import org.yamcs.api.YamcsSession;
-import org.yamcs.utils.PacketFormatter;
-import org.yamcs.utils.TimeEncoding;
 import org.yamcs.protobuf.Yamcs.EndAction;
 import org.yamcs.protobuf.Yamcs.NamedObjectId;
 import org.yamcs.protobuf.Yamcs.NamedObjectList;
+import org.yamcs.protobuf.Yamcs.PacketReplayRequest;
 import org.yamcs.protobuf.Yamcs.ProtoDataType;
 import org.yamcs.protobuf.Yamcs.ReplayRequest;
 import org.yamcs.protobuf.Yamcs.StringMessage;
 import org.yamcs.protobuf.Yamcs.TmPacketData;
 import org.yamcs.utils.CcsdsPacket;
+import org.yamcs.utils.PacketFormatter;
+import org.yamcs.utils.TimeEncoding;
+import org.yamcs.xtce.MdbMappings;
 
 import com.google.protobuf.InvalidProtocolBufferException;
 
@@ -61,238 +61,240 @@ import com.google.protobuf.InvalidProtocolBufferException;
  * GUI for requesting packet dumps
  */
 public class PacketRetrievalGui extends JFrame implements MessageHandler, ActionListener {
-	JCheckBox withoutCcsds;
-	JCheckBox pactsFakeHeaders;
-	JCheckBox printHex;
-	JButton startStop;
-	JFileChooser fileChooser;
-	List<String> packetNames;
-	long startInstant, stopInstant;
-	String archiveInstance;
-	Component parent;
-	ProgressMonitor progressMonitor;
-	private File outputFile;
-	private OutputStream outputStream;
-	ConnectionParameters connectionParams;
-	PacketFormatter packetFormatter;
-	YamcsSession ysession;
-	YamcsClient yclient;
-	
-	/**
-	 * Creates a new window that requests parameter deliveries
-	 * @param app
-	 * @param parent
-	 * @param packetNames
-	 * @param startTime
-	 * @param stopTime
-	 */
-	public PacketRetrievalGui(ConnectionParameters connectionParams, Component parent) {
-		super("Dump Telemetry Packets");
-		this.connectionParams=connectionParams;
-		this.parent=parent;
+    JCheckBox withoutCcsds;
+    JCheckBox pactsFakeHeaders;
+    JCheckBox printHex;
+    JButton startStop;
+    JFileChooser fileChooser;
+    List<String> packetNames;
+    long startInstant, stopInstant;
+    String archiveInstance;
+    Component parent;
+    ProgressMonitor progressMonitor;
+    private File outputFile;
+    private OutputStream outputStream;
+    ConnectionParameters connectionParams;
+    PacketFormatter packetFormatter;
+    YamcsSession ysession;
+    YamcsClient yclient;
 
-		Container frameContentPane=getContentPane();
-		frameContentPane.setLayout(new GridBagLayout());
-		GridBagConstraints gbc = new GridBagConstraints();
-		
-		
-		JLabel label=new JLabel("Dumping the selected telemetry packets into a file.");
-		gbc.gridx=0;gbc.gridy=0;gbc.gridwidth=GridBagConstraints.REMAINDER;
-		//gbc.ipadx=5; gbc.ipady=5;
-		gbc.insets=new Insets(5,5,5,5);
-		frameContentPane.add(label,gbc);
-		
-		//options
-		JPanel optionsPanel=new JPanel();
-		optionsPanel.setLayout(new BoxLayout(optionsPanel,BoxLayout.PAGE_AXIS));
-		optionsPanel.setBorder(BorderFactory.createCompoundBorder(BorderFactory.createTitledBorder("Options"),BorderFactory.createEmptyBorder(5,5,5,5)));
-		withoutCcsds=new JCheckBox("Remove the CCSDS headers");
-		optionsPanel.add(withoutCcsds);
-		printHex=new JCheckBox("Print in hexadecimal rather than binary");
-		optionsPanel.add(printHex);
-		pactsFakeHeaders=new JCheckBox("Add a fake 32 bytes PaCTS header");
-		optionsPanel.add(pactsFakeHeaders);
-		gbc.gridx=0;gbc.gridy=1;gbc.gridwidth=GridBagConstraints.REMAINDER;gbc.weightx = 1.0;gbc.fill = GridBagConstraints.HORIZONTAL;
-		frameContentPane.add(optionsPanel,gbc);
-		gbc.insets=new Insets(2,2,2,2);
-		
-		fileChooser=new JFileChooser("Select Output Directory");
-		fileChooser.setApproveButtonText("Save");
-		fileChooser.addActionListener(this);
+    /**
+     * Creates a new window that requests parameter deliveries
+     * @param app
+     * @param parent
+     * @param packetNames
+     * @param startTime
+     * @param stopTime
+     */
+    public PacketRetrievalGui(ConnectionParameters connectionParams, Component parent) {
+        super("Dump Telemetry Packets");
+        this.connectionParams=connectionParams;
+        this.parent=parent;
 
-		gbc.gridy=2;gbc.gridx=0;gbc.gridwidth=GridBagConstraints.REMAINDER;gbc.fill = GridBagConstraints.BOTH;
-		gbc.weighty = 1.0;gbc.weightx = 1.0;
-		frameContentPane.add(fileChooser,gbc);
-		
-		pack();
-	}
+        Container frameContentPane=getContentPane();
+        frameContentPane.setLayout(new GridBagLayout());
+        GridBagConstraints gbc = new GridBagConstraints();
 
-	public void setValues(String archiveInstance, List<String> packetNames, long start, long stop) {
-		this.packetNames=packetNames;
-		this.startInstant=start;
-		this.stopInstant=stop;
-		this.archiveInstance=archiveInstance;
 
-		if (packetNames.size() > 0) {
-			final String prefix = packetNames.get(0).split("_", 2)[0]; // use the prefix of the first packet name
+        JLabel label=new JLabel("Dumping the selected telemetry packets into a file.");
+        gbc.gridx=0;gbc.gridy=0;gbc.gridwidth=GridBagConstraints.REMAINDER;
+        //gbc.ipadx=5; gbc.ipady=5;
+        gbc.insets=new Insets(5,5,5,5);
+        frameContentPane.add(label,gbc);
 
-			String startWinCompatibleDateTime = TimeEncoding.toWinCompatibleDateTime(startInstant);
-			String stopWinCompatibleDateTime  = TimeEncoding.toWinCompatibleDateTime(stopInstant);
-									
-			String fileName = String.format("%s_packets_%s_%s.dump"
-													,prefix
-													,startWinCompatibleDateTime
-													,stopWinCompatibleDateTime);
-			fileChooser.setSelectedFile(new File(fileChooser.getSelectedFile(), fileName));
-		}
-	}
+        //options
+        JPanel optionsPanel=new JPanel();
+        optionsPanel.setLayout(new BoxLayout(optionsPanel,BoxLayout.PAGE_AXIS));
+        optionsPanel.setBorder(BorderFactory.createCompoundBorder(BorderFactory.createTitledBorder("Options"),BorderFactory.createEmptyBorder(5,5,5,5)));
+        withoutCcsds=new JCheckBox("Remove the CCSDS headers");
+        optionsPanel.add(withoutCcsds);
+        printHex=new JCheckBox("Print in hexadecimal rather than binary");
+        optionsPanel.add(printHex);
+        pactsFakeHeaders=new JCheckBox("Add a fake 32 bytes PaCTS header");
+        optionsPanel.add(pactsFakeHeaders);
+        gbc.gridx=0;gbc.gridy=1;gbc.gridwidth=GridBagConstraints.REMAINDER;gbc.weightx = 1.0;gbc.fill = GridBagConstraints.HORIZONTAL;
+        frameContentPane.add(optionsPanel,gbc);
+        gbc.insets=new Insets(2,2,2,2);
 
-	@Override
+        fileChooser=new JFileChooser("Select Output Directory");
+        fileChooser.setApproveButtonText("Save");
+        fileChooser.addActionListener(this);
+
+        gbc.gridy=2;gbc.gridx=0;gbc.gridwidth=GridBagConstraints.REMAINDER;gbc.fill = GridBagConstraints.BOTH;
+        gbc.weighty = 1.0;gbc.weightx = 1.0;
+        frameContentPane.add(fileChooser,gbc);
+
+        pack();
+    }
+
+    public void setValues(String archiveInstance, List<String> packetNames, long start, long stop) {
+        this.packetNames=packetNames;
+        this.startInstant=start;
+        this.stopInstant=stop;
+        this.archiveInstance=archiveInstance;
+
+        if (packetNames.size() > 0) {
+            final String prefix = packetNames.get(0).split("_", 2)[0]; // use the prefix of the first packet name
+
+            String startWinCompatibleDateTime = TimeEncoding.toWinCompatibleDateTime(startInstant);
+            String stopWinCompatibleDateTime  = TimeEncoding.toWinCompatibleDateTime(stopInstant);
+
+            String fileName = String.format("%s_packets_%s_%s.dump"
+                            ,prefix
+                            ,startWinCompatibleDateTime
+                            ,stopWinCompatibleDateTime);
+            fileChooser.setSelectedFile(new File(fileChooser.getSelectedFile(), fileName));
+        }
+    }
+
+    @Override
     public void actionPerformed(ActionEvent ae) {
-		String cmd = ae.getActionCommand();
-		if(cmd.equals("CancelSelection")) {
-			setVisible(false);
-		} else {
-			outputFile=fileChooser.getSelectedFile();
-			if(outputFile.exists()) {
-				if(JOptionPane.showConfirmDialog(this, "Are you sure you want to overwrite "+outputFile,"Overwrite file?",JOptionPane.YES_NO_OPTION,JOptionPane.WARNING_MESSAGE)
-						==JOptionPane.NO_OPTION) {
-					return;
-				}
-			}
-			setVisible(false);
-			count = 0;
-			downloadSize=0;
-			downloadStartTime=System.currentTimeMillis();
-			progressMonitor=new ProgressMonitor(parent,"Saving packets","0 packets saved",0,(int)((stopInstant-startInstant)/1000));
-			try {
-			    outputStream=new BufferedOutputStream(new FileOutputStream(outputFile));
-			    packetFormatter=new PacketFormatter(outputStream);
-			    packetFormatter.setHex(printHex.isSelected());
-			    packetFormatter.setWithoutCcsds(withoutCcsds.isSelected());
-			    packetFormatter.setWithPacts(pactsFakeHeaders.isSelected());
-
-			    YamcsConnectData ycd=(YamcsConnectData)connectionParams;
-			    ycd.instance=archiveInstance;
-			    ysession=YamcsSession.newBuilder().setConnectionParams(ycd).build();
-			    yclient=ysession.newClientBuilder().setRpc(true).setDataConsumer(null, null).build();
-			    ReplayRequest.Builder rr=ReplayRequest.newBuilder().setEndAction(EndAction.QUIT).addType(ProtoDataType.TM_PACKET)
-                    .setStart(startInstant).setStop(stopInstant);
-                for(String pn:packetNames) {
-                    rr.addTmPacketFilter(NamedObjectId.newBuilder().setNamespace(MdbMappings.MDB_OPSNAME).setName(pn).build());
+        String cmd = ae.getActionCommand();
+        if(cmd.equals("CancelSelection")) {
+            setVisible(false);
+        } else {
+            outputFile=fileChooser.getSelectedFile();
+            if(outputFile.exists()) {
+                if(JOptionPane.showConfirmDialog(this, "Are you sure you want to overwrite "+outputFile,"Overwrite file?",JOptionPane.YES_NO_OPTION,JOptionPane.WARNING_MESSAGE)
+                                ==JOptionPane.NO_OPTION) {
+                    return;
                 }
-			    StringMessage answer=(StringMessage) yclient.executeRpc(Protocol.getYarchReplayControlAddress(ycd.instance), "createReplay", rr.build(), StringMessage.newBuilder());
-			    SimpleString replayAddress=new SimpleString(answer.getMessage());
-                
-			    yclient.dataConsumer.setMessageHandler(this);
-			    yclient.executeRpc(replayAddress, "start", null, null);
-			} catch (FileNotFoundException e1) {
-				JOptionPane.showMessageDialog(parent, "Cannot open file: "+e1.getMessage(),"Cannot open file",JOptionPane.ERROR_MESSAGE);
-			} catch (YamcsException e) {
-				if("InvalidIdentification".equals(e.getType())) {
-					StringBuffer errorMessage = new StringBuffer( "Some packet names are invalid:\n" );
-					try {
-						NamedObjectList nol = (NamedObjectList) e.decodeExtra(NamedObjectList.newBuilder());
-						// Prevent error message causing dialog bigger than the screen
-						int itemNum = 0;
-						for( NamedObjectId noi : nol.getListList() ) {
-							errorMessage.append( noi.getName()+", " );
-							if( itemNum > 4 ) { itemNum = 0; errorMessage.append( '\n' ); }
-							itemNum ++;
-						}
-					} catch (InvalidProtocolBufferException e1) {
-						e1.printStackTrace();
-						errorMessage.append( "Sorry, unable to give more details." );
-					}
-					JOptionPane.showMessageDialog(parent, errorMessage.toString(),"Exception when retrieving data",JOptionPane.ERROR_MESSAGE);
-				} else {
-					JOptionPane.showMessageDialog(parent, "Exception when retrieving data: "+e.getMessage(),"Exception when retrieving data",JOptionPane.ERROR_MESSAGE);
-				}
-			} catch (Exception e) {
-			    e.printStackTrace();
-			    JOptionPane.showMessageDialog(parent, "Exception when retrieving data: "+e,"Exception when retrieving data",JOptionPane.ERROR_MESSAGE);
             }
-		}
-	}
-	
-	int count;
-	long downloadSize;
-	long downloadStartTime;
-	
-	@Override
-	public void onMessage(ClientMessage msg) {
-	    int t=msg.getIntProperty(DATA_TYPE_HEADER_NAME);
-	    ProtoDataType pdt=ProtoDataType.valueOf(t);
-	    if(pdt==ProtoDataType.STATE_CHANGE) {
-	        replayFinished();
-	        return;
-	    }
-	    if(pdt!=ProtoDataType.TM_PACKET) {
-	        exception(new Exception("Unexpected data type "+t));
-	        return;
-	    }
-	    TmPacketData data;
-	    try {
-	        data = (TmPacketData)decode(msg, TmPacketData.newBuilder());
-	        packetReceived(new CcsdsPacket(data.getPacket().asReadOnlyByteBuffer()));
-	    } catch (YamcsApiException e) {
-	        exception(e);
-	        e.printStackTrace();
-	        return;
-	    }
-	}
+            setVisible(false);
+            count = 0;
+            downloadSize=0;
+            downloadStartTime=System.currentTimeMillis();
+            progressMonitor=new ProgressMonitor(parent,"Saving packets","0 packets saved",0,(int)((stopInstant-startInstant)/1000));
+            try {
+                outputStream=new BufferedOutputStream(new FileOutputStream(outputFile));
+                packetFormatter=new PacketFormatter(outputStream);
+                packetFormatter.setHex(printHex.isSelected());
+                packetFormatter.setWithoutCcsds(withoutCcsds.isSelected());
+                packetFormatter.setWithPacts(pactsFakeHeaders.isSelected());
+
+                YamcsConnectData ycd=(YamcsConnectData)connectionParams;
+                ycd.instance=archiveInstance;
+                ysession=YamcsSession.newBuilder().setConnectionParams(ycd).build();
+                yclient=ysession.newClientBuilder().setRpc(true).setDataConsumer(null, null).build();
+                ReplayRequest.Builder rr=ReplayRequest.newBuilder().setEndAction(EndAction.QUIT)
+                                .setStart(startInstant).setStop(stopInstant);
+                PacketReplayRequest.Builder prr=PacketReplayRequest.newBuilder();
+                for(String pn:packetNames) {
+                    prr.addNameFilter(NamedObjectId.newBuilder().setNamespace(MdbMappings.MDB_OPSNAME).setName(pn));
+                }
+                rr.setPacketRequest(prr);
+                StringMessage answer=(StringMessage) yclient.executeRpc(Protocol.getYarchReplayControlAddress(ycd.instance), "createReplay", rr.build(), StringMessage.newBuilder());
+                SimpleString replayAddress=new SimpleString(answer.getMessage());
+
+                yclient.dataConsumer.setMessageHandler(this);
+                yclient.executeRpc(replayAddress, "start", null, null);
+            } catch (FileNotFoundException e1) {
+                JOptionPane.showMessageDialog(parent, "Cannot open file: "+e1.getMessage(),"Cannot open file",JOptionPane.ERROR_MESSAGE);
+            } catch (YamcsException e) {
+                if("InvalidIdentification".equals(e.getType())) {
+                    StringBuffer errorMessage = new StringBuffer( "Some packet names are invalid:\n" );
+                    try {
+                        NamedObjectList nol = (NamedObjectList) e.decodeExtra(NamedObjectList.newBuilder());
+                        // Prevent error message causing dialog bigger than the screen
+                        int itemNum = 0;
+                        for( NamedObjectId noi : nol.getListList() ) {
+                            errorMessage.append( noi.getName()+", " );
+                            if( itemNum > 4 ) { itemNum = 0; errorMessage.append( '\n' ); }
+                            itemNum ++;
+                        }
+                    } catch (InvalidProtocolBufferException e1) {
+                        e1.printStackTrace();
+                        errorMessage.append( "Sorry, unable to give more details." );
+                    }
+                    JOptionPane.showMessageDialog(parent, errorMessage.toString(),"Exception when retrieving data",JOptionPane.ERROR_MESSAGE);
+                } else {
+                    JOptionPane.showMessageDialog(parent, "Exception when retrieving data: "+e.getMessage(),"Exception when retrieving data",JOptionPane.ERROR_MESSAGE);
+                }
+            } catch (Exception e) {
+                e.printStackTrace();
+                JOptionPane.showMessageDialog(parent, "Exception when retrieving data: "+e,"Exception when retrieving data",JOptionPane.ERROR_MESSAGE);
+            }
+        }
+    }
+
+    int count;
+    long downloadSize;
+    long downloadStartTime;
+
+    @Override
+    public void onMessage(ClientMessage msg) {
+        int t=msg.getIntProperty(DATA_TYPE_HEADER_NAME);
+        ProtoDataType pdt=ProtoDataType.valueOf(t);
+        if(pdt==ProtoDataType.STATE_CHANGE) {
+            replayFinished();
+            return;
+        }
+        if(pdt!=ProtoDataType.TM_PACKET) {
+            exception(new Exception("Unexpected data type "+t));
+            return;
+        }
+        TmPacketData data;
+        try {
+            data = (TmPacketData)decode(msg, TmPacketData.newBuilder());
+            packetReceived(new CcsdsPacket(data.getPacket().asReadOnlyByteBuffer()));
+        } catch (YamcsApiException e) {
+            exception(e);
+            e.printStackTrace();
+            return;
+        }
+    }
 
     public void packetReceived(CcsdsPacket c) {
-		int progr=(int)((c.getInstant()-startInstant)/1000);
-		count++;
-		downloadSize+=c.getLength();
-		if(count%100==0) progressMonitor.setNote(count+" packets received");
-		progressMonitor.setProgress(progr);
-		try {
+        int progr=(int)((c.getInstant()-startInstant)/1000);
+        count++;
+        downloadSize+=c.getLength();
+        if(count%100==0) progressMonitor.setNote(count+" packets received");
+        progressMonitor.setProgress(progr);
+        try {
             packetFormatter.writePacket(c);
         } catch (IOException e) {
             e.printStackTrace();
         }
-	}
+    }
 
     private void replayFinished() {
-		try {
-		    yclient.close();
-			ysession.close();
-		} catch (HornetQException e1) {
-			e1.printStackTrace();
-		}
-		SwingUtilities.invokeLater(
-				new Runnable() {
-					@Override
-                    public void run() {
-						try {
-							packetFormatter.close();
-						} catch (IOException e) {
-							JOptionPane.showMessageDialog(parent, "Error when closing the output file: "+e.getMessage(), "Error when closing the output file", JOptionPane.ERROR_MESSAGE);
-						}
-						if(progressMonitor.isCanceled()) {
-							JOptionPane.showMessageDialog(parent, "Retrieval canceled. "+count+" packets retrieved");
-						} else {
-							progressMonitor.close();
-							float speed=(downloadSize*1000)/(1024*(System.currentTimeMillis()-downloadStartTime));
-							JOptionPane.showMessageDialog(parent, "The packet retrieval finished successfully. "+count+" packets retrieved in "+outputFile+". Retrieval speed: "+speed+" KiB/sec");
-						}
-					}
-				});
-	}
+        try {
+            yclient.close();
+            ysession.close();
+        } catch (HornetQException e1) {
+            e1.printStackTrace();
+        }
+        SwingUtilities.invokeLater(
+                        new Runnable() {
+                            @Override
+                            public void run() {
+                                try {
+                                    packetFormatter.close();
+                                } catch (IOException e) {
+                                    JOptionPane.showMessageDialog(parent, "Error when closing the output file: "+e.getMessage(), "Error when closing the output file", JOptionPane.ERROR_MESSAGE);
+                                }
+                                if(progressMonitor.isCanceled()) {
+                                    JOptionPane.showMessageDialog(parent, "Retrieval canceled. "+count+" packets retrieved");
+                                } else {
+                                    progressMonitor.close();
+                                    float speed=(downloadSize*1000)/(1024*(System.currentTimeMillis()-downloadStartTime));
+                                    JOptionPane.showMessageDialog(parent, "The packet retrieval finished successfully. "+count+" packets retrieved in "+outputFile+". Retrieval speed: "+speed+" KiB/sec");
+                                }
+                            }
+                        });
+    }
 
-	public void exception(final Exception e) {
-		final String message;
-		message=e.toString();
-		SwingUtilities.invokeLater(
-				new Runnable() {
-					@Override
-                    public void run() {
-						JOptionPane.showMessageDialog(parent, message, message, JOptionPane.ERROR_MESSAGE);
-						progressMonitor.close();
-					}
-				});
-	}
+    public void exception(final Exception e) {
+        final String message;
+        message=e.toString();
+        SwingUtilities.invokeLater(
+                        new Runnable() {
+                            @Override
+                            public void run() {
+                                JOptionPane.showMessageDialog(parent, message, message, JOptionPane.ERROR_MESSAGE);
+                                progressMonitor.close();
+                            }
+                        });
+    }
 }
 

--- a/yamcs-core/src/main/java/org/yamcs/ui/ParameterRetrievalGui.java
+++ b/yamcs-core/src/main/java/org/yamcs/ui/ParameterRetrievalGui.java
@@ -12,15 +12,15 @@ import java.awt.event.ActionListener;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.CharArrayReader;
+import java.io.File;
 import java.io.FileReader;
 import java.io.FileWriter;
-import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.prefs.*;
+import java.util.prefs.Preferences;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -40,16 +40,13 @@ import javax.swing.JTextArea;
 import javax.swing.JTextField;
 import javax.swing.ProgressMonitor;
 import javax.swing.SwingUtilities;
-import javax.swing.event.DocumentListener;
 import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
 
 import org.hornetq.api.core.SimpleString;
 import org.hornetq.api.core.client.ClientMessage;
 import org.hornetq.api.core.client.MessageHandler;
 import org.yamcs.YamcsException;
-import org.yamcs.xtce.MdbMappings;
-
-
 import org.yamcs.api.ConnectionListener;
 import org.yamcs.api.ConnectionParameters;
 import org.yamcs.api.Protocol;
@@ -57,8 +54,8 @@ import org.yamcs.api.YamcsApiException;
 import org.yamcs.api.YamcsClient;
 import org.yamcs.api.YamcsConnectData;
 import org.yamcs.api.YamcsSession;
-import org.yamcs.protobuf.Pvalue.ParameterValue;
 import org.yamcs.protobuf.Pvalue.ParameterData;
+import org.yamcs.protobuf.Pvalue.ParameterValue;
 import org.yamcs.protobuf.Yamcs.EndAction;
 import org.yamcs.protobuf.Yamcs.NamedObjectId;
 import org.yamcs.protobuf.Yamcs.NamedObjectList;
@@ -69,6 +66,7 @@ import org.yamcs.protobuf.Yamcs.StringMessage;
 import org.yamcs.utils.ParameterFormatter;
 import org.yamcs.utils.PetParameterFormatter;
 import org.yamcs.utils.TimeEncoding;
+import org.yamcs.xtce.MdbMappings;
 
 import com.google.protobuf.InvalidProtocolBufferException;
 
@@ -530,8 +528,8 @@ public class ParameterRetrievalGui extends JFrame implements MessageHandler, Con
 
             ysession=YamcsSession.newBuilder().setConnectionParams(ycd).build();
             yclient=ysession.newClientBuilder().setRpc(true).setDataConsumer(null, null).build();
-            ParameterReplayRequest prr=ParameterReplayRequest.newBuilder().addAllParameter(paramList).build();
-            ReplayRequest rr=ReplayRequest.newBuilder().setEndAction(EndAction.QUIT).addType(ProtoDataType.PARAMETER)
+            ParameterReplayRequest prr=ParameterReplayRequest.newBuilder().addAllNameFilter(paramList).build();
+            ReplayRequest rr=ReplayRequest.newBuilder().setEndAction(EndAction.QUIT)
                 .setParameterRequest(prr).setStart(start).setStop(stop).build();
             
             StringMessage answer=(StringMessage) yclient.executeRpc(Protocol.getYarchReplayControlAddress(ycd.instance), "createReplay", rr, StringMessage.newBuilder());

--- a/yamcs-core/src/main/java/org/yamcs/ui/eventviewer/YamcsEventReceiver.java
+++ b/yamcs-core/src/main/java/org/yamcs/ui/eventviewer/YamcsEventReceiver.java
@@ -25,18 +25,17 @@ import org.hornetq.api.core.SimpleString;
 import org.hornetq.api.core.client.ClientMessage;
 import org.hornetq.api.core.client.MessageHandler;
 import org.hornetq.api.core.client.SessionFailureListener;
-
 import org.yamcs.YamcsException;
 import org.yamcs.api.ConnectionListener;
-import org.yamcs.api.YamcsConnector;
 import org.yamcs.api.Protocol;
 import org.yamcs.api.YamcsClient;
-import org.yamcs.utils.TimeEncoding;
+import org.yamcs.api.YamcsConnector;
 import org.yamcs.protobuf.Yamcs.EndAction;
 import org.yamcs.protobuf.Yamcs.Event;
-import org.yamcs.protobuf.Yamcs.ProtoDataType;
+import org.yamcs.protobuf.Yamcs.EventReplayRequest;
 import org.yamcs.protobuf.Yamcs.ReplayRequest;
 import org.yamcs.protobuf.Yamcs.StringMessage;
+import org.yamcs.utils.TimeEncoding;
 
 public class YamcsEventReceiver implements ConnectionListener, EventReceiver, MessageHandler, SessionFailureListener {
     EventViewer eventViewer;
@@ -200,8 +199,9 @@ public class YamcsEventReceiver implements ConnectionListener, EventReceiver, Me
                 YamcsClient msgClient=yconnector.getSession().newClientBuilder().setRpc(true).setDataConsumer(null, null).
                     build();
                
-                ReplayRequest crr=ReplayRequest.newBuilder().addType(ProtoDataType.EVENT).setStart(params.start).setStop(params.stop).
-                        setEndAction(EndAction.QUIT).build();
+                EventReplayRequest err=EventReplayRequest.newBuilder().build();
+                ReplayRequest crr=ReplayRequest.newBuilder().setStart(params.start).setStop(params.stop).
+                        setEndAction(EndAction.QUIT).setEventRequest(err).build();
                 
                 SimpleString replayServer=Protocol.getYarchReplayControlAddress(yconnector.getConnectionParams().getInstance());
                 StringMessage answer=(StringMessage) msgClient.executeRpc(replayServer, "createReplay", crr, StringMessage.newBuilder());

--- a/yamcs-core/src/test/java/org/yamcs/archive/TestCmdHistoryRecording.java
+++ b/yamcs-core/src/test/java/org/yamcs/archive/TestCmdHistoryRecording.java
@@ -1,6 +1,7 @@
 package org.yamcs.archive;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.yamcs.api.Protocol.decode;
 
 import java.util.concurrent.Semaphore;
@@ -14,11 +15,6 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.yamcs.YamcsServer;
-import org.yamcs.archive.ReplayServer;
-import org.yamcs.yarch.Stream;
-import org.yamcs.yarch.StreamSubscriber;
-import org.yamcs.yarch.Tuple;
-
 import org.yamcs.api.Protocol;
 import org.yamcs.api.YamcsClient;
 import org.yamcs.api.YamcsSession;
@@ -27,10 +23,14 @@ import org.yamcs.cmdhistory.YarchCommandHistoryAdapter;
 import org.yamcs.commanding.PreparedCommand;
 import org.yamcs.protobuf.Commanding.CommandHistoryEntry;
 import org.yamcs.protobuf.Commanding.CommandId;
-import org.yamcs.protobuf.Yamcs.ProtoDataType;
+import org.yamcs.protobuf.Yamcs.CommandHistoryReplayRequest;
 import org.yamcs.protobuf.Yamcs.EndAction;
+import org.yamcs.protobuf.Yamcs.ProtoDataType;
 import org.yamcs.protobuf.Yamcs.ReplayRequest;
 import org.yamcs.protobuf.Yamcs.StringMessage;
+import org.yamcs.yarch.Stream;
+import org.yamcs.yarch.StreamSubscriber;
+import org.yamcs.yarch.Tuple;
 import org.yamcs.yarch.YarchTestCase;
 
 /**
@@ -106,8 +106,9 @@ public class TestCmdHistoryRecording extends YarchTestCase {
         YamcsClient yclient=ysession.newClientBuilder().setRpc(true).setDataConsumer(null, null).build();
         
         
+        CommandHistoryReplayRequest chr = CommandHistoryReplayRequest.newBuilder().build();
         ReplayRequest rr=ReplayRequest.newBuilder().setEndAction(EndAction.QUIT).
-                    addType(ProtoDataType.CMD_HISTORY).build();
+                    setCommandHistoryRequest(chr).build();
         SimpleString replayServer=Protocol.getYarchReplayControlAddress(ydb.getName());
         StringMessage answer=(StringMessage) yclient.executeRpc(replayServer, "createReplay", rr, StringMessage.newBuilder());
         

--- a/yamcs-core/src/test/java/org/yamcs/archive/TestEventRecording.java
+++ b/yamcs-core/src/test/java/org/yamcs/archive/TestEventRecording.java
@@ -1,6 +1,8 @@
 package org.yamcs.archive;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
 import static org.yamcs.api.Protocol.decode;
 
 import java.util.concurrent.Semaphore;
@@ -15,26 +17,23 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.yamcs.YamcsServer;
-import org.yamcs.archive.EventRecorder;
-import org.yamcs.archive.EventTupleTranslator;
-import org.yamcs.archive.ReplayServer;
-import org.yamcs.yarch.Stream;
-import org.yamcs.yarch.StreamSubscriber;
-import org.yamcs.yarch.Tuple;
-import org.yamcs.yarch.hornet.StreamAdapter;
-
 import org.yamcs.api.Protocol;
 import org.yamcs.api.YamcsApiException;
 import org.yamcs.api.YamcsClient;
-import org.yamcs.api.YamcsSession;
 import org.yamcs.api.YamcsClient.ClientBuilder;
-import org.yamcs.protobuf.Yamcs.ProtoDataType;
+import org.yamcs.api.YamcsSession;
 import org.yamcs.protobuf.Yamcs.EndAction;
 import org.yamcs.protobuf.Yamcs.Event;
+import org.yamcs.protobuf.Yamcs.Event.EventSeverity;
+import org.yamcs.protobuf.Yamcs.EventReplayRequest;
+import org.yamcs.protobuf.Yamcs.ProtoDataType;
 import org.yamcs.protobuf.Yamcs.ReplayRequest;
 import org.yamcs.protobuf.Yamcs.StringMessage;
-import org.yamcs.protobuf.Yamcs.Event.EventSeverity;
+import org.yamcs.yarch.Stream;
+import org.yamcs.yarch.StreamSubscriber;
+import org.yamcs.yarch.Tuple;
 import org.yamcs.yarch.YarchTestCase;
+import org.yamcs.yarch.hornet.StreamAdapter;
 
 /**
  * Generates and saves some some events and then it performs a replay via HornetQ
@@ -132,8 +131,9 @@ public class TestEventRecording extends YarchTestCase {
         msgClient=ys.newClientBuilder().setRpc(true).setDataConsumer(null, null).build();
         
         
+        EventReplayRequest err=EventReplayRequest.newBuilder().build();
         ReplayRequest rr=ReplayRequest.newBuilder().setEndAction(EndAction.QUIT).
-                    addType(ProtoDataType.EVENT).build();
+                    setEventRequest(err).build();
         SimpleString replayServer=Protocol.getYarchReplayControlAddress(context.getDbName());
         StringMessage answer=(StringMessage) msgClient.executeRpc(replayServer, "createReplay", rr, StringMessage.newBuilder());
         

--- a/yamcs-web/src/main/java/org/yamcs/protobuf/SchemaYamcs.java
+++ b/yamcs-web/src/main/java/org/yamcs/protobuf/SchemaYamcs.java
@@ -2592,6 +2592,18 @@ public final class SchemaYamcs
                 if(message.hasParameterRequest())
                     output.writeObject(8, message.getParameterRequest(), org.yamcs.protobuf.SchemaYamcs.ParameterReplayRequest.WRITE, false);
 
+                if(message.hasPacketRequest())
+                    output.writeObject(9, message.getPacketRequest(), org.yamcs.protobuf.SchemaYamcs.PacketReplayRequest.WRITE, false);
+
+                if(message.hasEventRequest())
+                    output.writeObject(10, message.getEventRequest(), org.yamcs.protobuf.SchemaYamcs.EventReplayRequest.WRITE, false);
+
+                if(message.hasCommandHistoryRequest())
+                    output.writeObject(11, message.getCommandHistoryRequest(), org.yamcs.protobuf.SchemaYamcs.CommandHistoryReplayRequest.WRITE, false);
+
+                if(message.hasPpRequest())
+                    output.writeObject(12, message.getPpRequest(), org.yamcs.protobuf.SchemaYamcs.PpReplayRequest.WRITE, false);
+
             }
             public boolean isInitialized(org.yamcs.protobuf.Yamcs.ReplayRequest message)
             {
@@ -2658,6 +2670,22 @@ public final class SchemaYamcs
                             builder.setParameterRequest(input.mergeObject(org.yamcs.protobuf.Yamcs.ParameterReplayRequest.newBuilder(), org.yamcs.protobuf.SchemaYamcs.ParameterReplayRequest.MERGE));
 
                             break;
+                        case 9:
+                            builder.setPacketRequest(input.mergeObject(org.yamcs.protobuf.Yamcs.PacketReplayRequest.newBuilder(), org.yamcs.protobuf.SchemaYamcs.PacketReplayRequest.MERGE));
+
+                            break;
+                        case 10:
+                            builder.setEventRequest(input.mergeObject(org.yamcs.protobuf.Yamcs.EventReplayRequest.newBuilder(), org.yamcs.protobuf.SchemaYamcs.EventReplayRequest.MERGE));
+
+                            break;
+                        case 11:
+                            builder.setCommandHistoryRequest(input.mergeObject(org.yamcs.protobuf.Yamcs.CommandHistoryReplayRequest.newBuilder(), org.yamcs.protobuf.SchemaYamcs.CommandHistoryReplayRequest.MERGE));
+
+                            break;
+                        case 12:
+                            builder.setPpRequest(input.mergeObject(org.yamcs.protobuf.Yamcs.PpReplayRequest.newBuilder(), org.yamcs.protobuf.SchemaYamcs.PpReplayRequest.MERGE));
+
+                            break;
                         default:
                             input.handleUnknownField(number, this);
                     }
@@ -2706,6 +2734,10 @@ public final class SchemaYamcs
                 case 6: return "tmPacketFilter";
                 case 7: return "ppGroupFilter";
                 case 8: return "parameterRequest";
+                case 9: return "packetRequest";
+                case 10: return "eventRequest";
+                case 11: return "commandHistoryRequest";
+                case 12: return "ppRequest";
                 default: return null;
             }
         }
@@ -2725,6 +2757,10 @@ public final class SchemaYamcs
             fieldMap.put("tmPacketFilter", 6);
             fieldMap.put("ppGroupFilter", 7);
             fieldMap.put("parameterRequest", 8);
+            fieldMap.put("packetRequest", 9);
+            fieldMap.put("eventRequest", 10);
+            fieldMap.put("commandHistoryRequest", 11);
+            fieldMap.put("ppRequest", 12);
         }
     }
 
@@ -2739,8 +2775,8 @@ public final class SchemaYamcs
         {
             public void writeTo(com.dyuproject.protostuff.Output output, org.yamcs.protobuf.Yamcs.ParameterReplayRequest message) throws java.io.IOException
             {
-                for(org.yamcs.protobuf.Yamcs.NamedObjectId parameter : message.getParameterList())
-                    output.writeObject(1, parameter, org.yamcs.protobuf.SchemaYamcs.NamedObjectId.WRITE, true);
+                for(org.yamcs.protobuf.Yamcs.NamedObjectId nameFilter : message.getNameFilterList())
+                    output.writeObject(1, nameFilter, org.yamcs.protobuf.SchemaYamcs.NamedObjectId.WRITE, true);
 
                 if(message.hasSendRaw())
                     output.writeBool(2, message.getSendRaw(), false);
@@ -2786,7 +2822,7 @@ public final class SchemaYamcs
                         case 0:
                             return;
                         case 1:
-                            builder.addParameter(input.mergeObject(org.yamcs.protobuf.Yamcs.NamedObjectId.newBuilder(), org.yamcs.protobuf.SchemaYamcs.NamedObjectId.MERGE));
+                            builder.addNameFilter(input.mergeObject(org.yamcs.protobuf.Yamcs.NamedObjectId.newBuilder(), org.yamcs.protobuf.SchemaYamcs.NamedObjectId.MERGE));
 
                             break;
                         case 2:
@@ -2835,7 +2871,7 @@ public final class SchemaYamcs
         {
             switch(number)
             {
-                case 1: return "parameter";
+                case 1: return "nameFilter";
                 case 2: return "sendRaw";
                 case 3: return "performMonitoring";
                 default: return null;
@@ -2849,9 +2885,441 @@ public final class SchemaYamcs
         private static final java.util.HashMap<java.lang.String,java.lang.Integer> fieldMap = new java.util.HashMap<java.lang.String,java.lang.Integer>();
         static
         {
-            fieldMap.put("parameter", 1);
+            fieldMap.put("nameFilter", 1);
             fieldMap.put("sendRaw", 2);
             fieldMap.put("performMonitoring", 3);
+        }
+    }
+
+    public static final class PacketReplayRequest
+    {
+        public static final org.yamcs.protobuf.SchemaYamcs.PacketReplayRequest.MessageSchema WRITE =
+            new org.yamcs.protobuf.SchemaYamcs.PacketReplayRequest.MessageSchema();
+        public static final org.yamcs.protobuf.SchemaYamcs.PacketReplayRequest.BuilderSchema MERGE =
+            new org.yamcs.protobuf.SchemaYamcs.PacketReplayRequest.BuilderSchema();
+        
+        public static class MessageSchema implements com.dyuproject.protostuff.Schema<org.yamcs.protobuf.Yamcs.PacketReplayRequest>
+        {
+            public void writeTo(com.dyuproject.protostuff.Output output, org.yamcs.protobuf.Yamcs.PacketReplayRequest message) throws java.io.IOException
+            {
+                for(org.yamcs.protobuf.Yamcs.NamedObjectId nameFilter : message.getNameFilterList())
+                    output.writeObject(1, nameFilter, org.yamcs.protobuf.SchemaYamcs.NamedObjectId.WRITE, true);
+
+            }
+            public boolean isInitialized(org.yamcs.protobuf.Yamcs.PacketReplayRequest message)
+            {
+                return message.isInitialized();
+            }
+            public java.lang.String getFieldName(int number)
+            {
+                return org.yamcs.protobuf.SchemaYamcs.PacketReplayRequest.getFieldName(number);
+            }
+            public int getFieldNumber(java.lang.String name)
+            {
+                return org.yamcs.protobuf.SchemaYamcs.PacketReplayRequest.getFieldNumber(name);
+            }
+            public java.lang.Class<org.yamcs.protobuf.Yamcs.PacketReplayRequest> typeClass()
+            {
+                return org.yamcs.protobuf.Yamcs.PacketReplayRequest.class;
+            }
+            public java.lang.String messageName()
+            {
+                return org.yamcs.protobuf.Yamcs.PacketReplayRequest.class.getSimpleName();
+            }
+            public java.lang.String messageFullName()
+            {
+                return org.yamcs.protobuf.Yamcs.PacketReplayRequest.class.getName();
+            }
+            //unused
+            public void mergeFrom(com.dyuproject.protostuff.Input input, org.yamcs.protobuf.Yamcs.PacketReplayRequest message) throws java.io.IOException {}
+            public org.yamcs.protobuf.Yamcs.PacketReplayRequest newMessage() { return null; }
+        }
+        public static class BuilderSchema implements com.dyuproject.protostuff.Schema<org.yamcs.protobuf.Yamcs.PacketReplayRequest.Builder>
+        {
+            public void mergeFrom(com.dyuproject.protostuff.Input input, org.yamcs.protobuf.Yamcs.PacketReplayRequest.Builder builder) throws java.io.IOException
+            {
+                for(int number = input.readFieldNumber(this);; number = input.readFieldNumber(this))
+                {
+                    switch(number)
+                    {
+                        case 0:
+                            return;
+                        case 1:
+                            builder.addNameFilter(input.mergeObject(org.yamcs.protobuf.Yamcs.NamedObjectId.newBuilder(), org.yamcs.protobuf.SchemaYamcs.NamedObjectId.MERGE));
+
+                            break;
+                        default:
+                            input.handleUnknownField(number, this);
+                    }
+                }
+            }
+            public boolean isInitialized(org.yamcs.protobuf.Yamcs.PacketReplayRequest.Builder builder)
+            {
+                return builder.isInitialized();
+            }
+            public org.yamcs.protobuf.Yamcs.PacketReplayRequest.Builder newMessage()
+            {
+                return org.yamcs.protobuf.Yamcs.PacketReplayRequest.newBuilder();
+            }
+            public java.lang.String getFieldName(int number)
+            {
+                return org.yamcs.protobuf.SchemaYamcs.PacketReplayRequest.getFieldName(number);
+            }
+            public int getFieldNumber(java.lang.String name)
+            {
+                return org.yamcs.protobuf.SchemaYamcs.PacketReplayRequest.getFieldNumber(name);
+            }
+            public java.lang.Class<org.yamcs.protobuf.Yamcs.PacketReplayRequest.Builder> typeClass()
+            {
+                return org.yamcs.protobuf.Yamcs.PacketReplayRequest.Builder.class;
+            }
+            public java.lang.String messageName()
+            {
+                return org.yamcs.protobuf.Yamcs.PacketReplayRequest.class.getSimpleName();
+            }
+            public java.lang.String messageFullName()
+            {
+                return org.yamcs.protobuf.Yamcs.PacketReplayRequest.class.getName();
+            }
+            //unused
+            public void writeTo(com.dyuproject.protostuff.Output output, org.yamcs.protobuf.Yamcs.PacketReplayRequest.Builder builder) throws java.io.IOException {}
+        }
+        public static java.lang.String getFieldName(int number)
+        {
+            switch(number)
+            {
+                case 1: return "nameFilter";
+                default: return null;
+            }
+        }
+        public static int getFieldNumber(java.lang.String name)
+        {
+            java.lang.Integer number = fieldMap.get(name);
+            return number == null ? 0 : number.intValue();
+        }
+        private static final java.util.HashMap<java.lang.String,java.lang.Integer> fieldMap = new java.util.HashMap<java.lang.String,java.lang.Integer>();
+        static
+        {
+            fieldMap.put("nameFilter", 1);
+        }
+    }
+
+    public static final class EventReplayRequest
+    {
+        public static final org.yamcs.protobuf.SchemaYamcs.EventReplayRequest.MessageSchema WRITE =
+            new org.yamcs.protobuf.SchemaYamcs.EventReplayRequest.MessageSchema();
+        public static final org.yamcs.protobuf.SchemaYamcs.EventReplayRequest.BuilderSchema MERGE =
+            new org.yamcs.protobuf.SchemaYamcs.EventReplayRequest.BuilderSchema();
+        
+        public static class MessageSchema implements com.dyuproject.protostuff.Schema<org.yamcs.protobuf.Yamcs.EventReplayRequest>
+        {
+            public void writeTo(com.dyuproject.protostuff.Output output, org.yamcs.protobuf.Yamcs.EventReplayRequest message) throws java.io.IOException
+            {
+            }
+            public boolean isInitialized(org.yamcs.protobuf.Yamcs.EventReplayRequest message)
+            {
+                return message.isInitialized();
+            }
+            public java.lang.String getFieldName(int number)
+            {
+                return org.yamcs.protobuf.SchemaYamcs.EventReplayRequest.getFieldName(number);
+            }
+            public int getFieldNumber(java.lang.String name)
+            {
+                return org.yamcs.protobuf.SchemaYamcs.EventReplayRequest.getFieldNumber(name);
+            }
+            public java.lang.Class<org.yamcs.protobuf.Yamcs.EventReplayRequest> typeClass()
+            {
+                return org.yamcs.protobuf.Yamcs.EventReplayRequest.class;
+            }
+            public java.lang.String messageName()
+            {
+                return org.yamcs.protobuf.Yamcs.EventReplayRequest.class.getSimpleName();
+            }
+            public java.lang.String messageFullName()
+            {
+                return org.yamcs.protobuf.Yamcs.EventReplayRequest.class.getName();
+            }
+            //unused
+            public void mergeFrom(com.dyuproject.protostuff.Input input, org.yamcs.protobuf.Yamcs.EventReplayRequest message) throws java.io.IOException {}
+            public org.yamcs.protobuf.Yamcs.EventReplayRequest newMessage() { return null; }
+        }
+        public static class BuilderSchema implements com.dyuproject.protostuff.Schema<org.yamcs.protobuf.Yamcs.EventReplayRequest.Builder>
+        {
+            public void mergeFrom(com.dyuproject.protostuff.Input input, org.yamcs.protobuf.Yamcs.EventReplayRequest.Builder builder) throws java.io.IOException
+            {
+                for(int number = input.readFieldNumber(this);; number = input.readFieldNumber(this))
+                {
+                    switch(number)
+                    {
+                        case 0:
+                            return;
+                        default:
+                            input.handleUnknownField(number, this);
+                    }
+                }
+            }
+            public boolean isInitialized(org.yamcs.protobuf.Yamcs.EventReplayRequest.Builder builder)
+            {
+                return builder.isInitialized();
+            }
+            public org.yamcs.protobuf.Yamcs.EventReplayRequest.Builder newMessage()
+            {
+                return org.yamcs.protobuf.Yamcs.EventReplayRequest.newBuilder();
+            }
+            public java.lang.String getFieldName(int number)
+            {
+                return org.yamcs.protobuf.SchemaYamcs.EventReplayRequest.getFieldName(number);
+            }
+            public int getFieldNumber(java.lang.String name)
+            {
+                return org.yamcs.protobuf.SchemaYamcs.EventReplayRequest.getFieldNumber(name);
+            }
+            public java.lang.Class<org.yamcs.protobuf.Yamcs.EventReplayRequest.Builder> typeClass()
+            {
+                return org.yamcs.protobuf.Yamcs.EventReplayRequest.Builder.class;
+            }
+            public java.lang.String messageName()
+            {
+                return org.yamcs.protobuf.Yamcs.EventReplayRequest.class.getSimpleName();
+            }
+            public java.lang.String messageFullName()
+            {
+                return org.yamcs.protobuf.Yamcs.EventReplayRequest.class.getName();
+            }
+            //unused
+            public void writeTo(com.dyuproject.protostuff.Output output, org.yamcs.protobuf.Yamcs.EventReplayRequest.Builder builder) throws java.io.IOException {}
+        }
+        public static java.lang.String getFieldName(int number)
+        {
+            switch(number)
+            {
+                default: return null;
+            }
+        }
+        public static int getFieldNumber(java.lang.String name)
+        {
+            java.lang.Integer number = fieldMap.get(name);
+            return number == null ? 0 : number.intValue();
+        }
+        private static final java.util.HashMap<java.lang.String,java.lang.Integer> fieldMap = new java.util.HashMap<java.lang.String,java.lang.Integer>();
+        static
+        {
+        }
+    }
+
+    public static final class CommandHistoryReplayRequest
+    {
+        public static final org.yamcs.protobuf.SchemaYamcs.CommandHistoryReplayRequest.MessageSchema WRITE =
+            new org.yamcs.protobuf.SchemaYamcs.CommandHistoryReplayRequest.MessageSchema();
+        public static final org.yamcs.protobuf.SchemaYamcs.CommandHistoryReplayRequest.BuilderSchema MERGE =
+            new org.yamcs.protobuf.SchemaYamcs.CommandHistoryReplayRequest.BuilderSchema();
+        
+        public static class MessageSchema implements com.dyuproject.protostuff.Schema<org.yamcs.protobuf.Yamcs.CommandHistoryReplayRequest>
+        {
+            public void writeTo(com.dyuproject.protostuff.Output output, org.yamcs.protobuf.Yamcs.CommandHistoryReplayRequest message) throws java.io.IOException
+            {
+            }
+            public boolean isInitialized(org.yamcs.protobuf.Yamcs.CommandHistoryReplayRequest message)
+            {
+                return message.isInitialized();
+            }
+            public java.lang.String getFieldName(int number)
+            {
+                return org.yamcs.protobuf.SchemaYamcs.CommandHistoryReplayRequest.getFieldName(number);
+            }
+            public int getFieldNumber(java.lang.String name)
+            {
+                return org.yamcs.protobuf.SchemaYamcs.CommandHistoryReplayRequest.getFieldNumber(name);
+            }
+            public java.lang.Class<org.yamcs.protobuf.Yamcs.CommandHistoryReplayRequest> typeClass()
+            {
+                return org.yamcs.protobuf.Yamcs.CommandHistoryReplayRequest.class;
+            }
+            public java.lang.String messageName()
+            {
+                return org.yamcs.protobuf.Yamcs.CommandHistoryReplayRequest.class.getSimpleName();
+            }
+            public java.lang.String messageFullName()
+            {
+                return org.yamcs.protobuf.Yamcs.CommandHistoryReplayRequest.class.getName();
+            }
+            //unused
+            public void mergeFrom(com.dyuproject.protostuff.Input input, org.yamcs.protobuf.Yamcs.CommandHistoryReplayRequest message) throws java.io.IOException {}
+            public org.yamcs.protobuf.Yamcs.CommandHistoryReplayRequest newMessage() { return null; }
+        }
+        public static class BuilderSchema implements com.dyuproject.protostuff.Schema<org.yamcs.protobuf.Yamcs.CommandHistoryReplayRequest.Builder>
+        {
+            public void mergeFrom(com.dyuproject.protostuff.Input input, org.yamcs.protobuf.Yamcs.CommandHistoryReplayRequest.Builder builder) throws java.io.IOException
+            {
+                for(int number = input.readFieldNumber(this);; number = input.readFieldNumber(this))
+                {
+                    switch(number)
+                    {
+                        case 0:
+                            return;
+                        default:
+                            input.handleUnknownField(number, this);
+                    }
+                }
+            }
+            public boolean isInitialized(org.yamcs.protobuf.Yamcs.CommandHistoryReplayRequest.Builder builder)
+            {
+                return builder.isInitialized();
+            }
+            public org.yamcs.protobuf.Yamcs.CommandHistoryReplayRequest.Builder newMessage()
+            {
+                return org.yamcs.protobuf.Yamcs.CommandHistoryReplayRequest.newBuilder();
+            }
+            public java.lang.String getFieldName(int number)
+            {
+                return org.yamcs.protobuf.SchemaYamcs.CommandHistoryReplayRequest.getFieldName(number);
+            }
+            public int getFieldNumber(java.lang.String name)
+            {
+                return org.yamcs.protobuf.SchemaYamcs.CommandHistoryReplayRequest.getFieldNumber(name);
+            }
+            public java.lang.Class<org.yamcs.protobuf.Yamcs.CommandHistoryReplayRequest.Builder> typeClass()
+            {
+                return org.yamcs.protobuf.Yamcs.CommandHistoryReplayRequest.Builder.class;
+            }
+            public java.lang.String messageName()
+            {
+                return org.yamcs.protobuf.Yamcs.CommandHistoryReplayRequest.class.getSimpleName();
+            }
+            public java.lang.String messageFullName()
+            {
+                return org.yamcs.protobuf.Yamcs.CommandHistoryReplayRequest.class.getName();
+            }
+            //unused
+            public void writeTo(com.dyuproject.protostuff.Output output, org.yamcs.protobuf.Yamcs.CommandHistoryReplayRequest.Builder builder) throws java.io.IOException {}
+        }
+        public static java.lang.String getFieldName(int number)
+        {
+            switch(number)
+            {
+                default: return null;
+            }
+        }
+        public static int getFieldNumber(java.lang.String name)
+        {
+            java.lang.Integer number = fieldMap.get(name);
+            return number == null ? 0 : number.intValue();
+        }
+        private static final java.util.HashMap<java.lang.String,java.lang.Integer> fieldMap = new java.util.HashMap<java.lang.String,java.lang.Integer>();
+        static
+        {
+        }
+    }
+
+    public static final class PpReplayRequest
+    {
+        public static final org.yamcs.protobuf.SchemaYamcs.PpReplayRequest.MessageSchema WRITE =
+            new org.yamcs.protobuf.SchemaYamcs.PpReplayRequest.MessageSchema();
+        public static final org.yamcs.protobuf.SchemaYamcs.PpReplayRequest.BuilderSchema MERGE =
+            new org.yamcs.protobuf.SchemaYamcs.PpReplayRequest.BuilderSchema();
+        
+        public static class MessageSchema implements com.dyuproject.protostuff.Schema<org.yamcs.protobuf.Yamcs.PpReplayRequest>
+        {
+            public void writeTo(com.dyuproject.protostuff.Output output, org.yamcs.protobuf.Yamcs.PpReplayRequest message) throws java.io.IOException
+            {
+                for(String groupNameFilter : message.getGroupNameFilterList())
+                    output.writeString(1, groupNameFilter, true);
+            }
+            public boolean isInitialized(org.yamcs.protobuf.Yamcs.PpReplayRequest message)
+            {
+                return message.isInitialized();
+            }
+            public java.lang.String getFieldName(int number)
+            {
+                return org.yamcs.protobuf.SchemaYamcs.PpReplayRequest.getFieldName(number);
+            }
+            public int getFieldNumber(java.lang.String name)
+            {
+                return org.yamcs.protobuf.SchemaYamcs.PpReplayRequest.getFieldNumber(name);
+            }
+            public java.lang.Class<org.yamcs.protobuf.Yamcs.PpReplayRequest> typeClass()
+            {
+                return org.yamcs.protobuf.Yamcs.PpReplayRequest.class;
+            }
+            public java.lang.String messageName()
+            {
+                return org.yamcs.protobuf.Yamcs.PpReplayRequest.class.getSimpleName();
+            }
+            public java.lang.String messageFullName()
+            {
+                return org.yamcs.protobuf.Yamcs.PpReplayRequest.class.getName();
+            }
+            //unused
+            public void mergeFrom(com.dyuproject.protostuff.Input input, org.yamcs.protobuf.Yamcs.PpReplayRequest message) throws java.io.IOException {}
+            public org.yamcs.protobuf.Yamcs.PpReplayRequest newMessage() { return null; }
+        }
+        public static class BuilderSchema implements com.dyuproject.protostuff.Schema<org.yamcs.protobuf.Yamcs.PpReplayRequest.Builder>
+        {
+            public void mergeFrom(com.dyuproject.protostuff.Input input, org.yamcs.protobuf.Yamcs.PpReplayRequest.Builder builder) throws java.io.IOException
+            {
+                for(int number = input.readFieldNumber(this);; number = input.readFieldNumber(this))
+                {
+                    switch(number)
+                    {
+                        case 0:
+                            return;
+                        case 1:
+                            builder.addGroupNameFilter(input.readString());
+                            break;
+                        default:
+                            input.handleUnknownField(number, this);
+                    }
+                }
+            }
+            public boolean isInitialized(org.yamcs.protobuf.Yamcs.PpReplayRequest.Builder builder)
+            {
+                return builder.isInitialized();
+            }
+            public org.yamcs.protobuf.Yamcs.PpReplayRequest.Builder newMessage()
+            {
+                return org.yamcs.protobuf.Yamcs.PpReplayRequest.newBuilder();
+            }
+            public java.lang.String getFieldName(int number)
+            {
+                return org.yamcs.protobuf.SchemaYamcs.PpReplayRequest.getFieldName(number);
+            }
+            public int getFieldNumber(java.lang.String name)
+            {
+                return org.yamcs.protobuf.SchemaYamcs.PpReplayRequest.getFieldNumber(name);
+            }
+            public java.lang.Class<org.yamcs.protobuf.Yamcs.PpReplayRequest.Builder> typeClass()
+            {
+                return org.yamcs.protobuf.Yamcs.PpReplayRequest.Builder.class;
+            }
+            public java.lang.String messageName()
+            {
+                return org.yamcs.protobuf.Yamcs.PpReplayRequest.class.getSimpleName();
+            }
+            public java.lang.String messageFullName()
+            {
+                return org.yamcs.protobuf.Yamcs.PpReplayRequest.class.getName();
+            }
+            //unused
+            public void writeTo(com.dyuproject.protostuff.Output output, org.yamcs.protobuf.Yamcs.PpReplayRequest.Builder builder) throws java.io.IOException {}
+        }
+        public static java.lang.String getFieldName(int number)
+        {
+            switch(number)
+            {
+                case 1: return "groupNameFilter";
+                default: return null;
+            }
+        }
+        public static int getFieldNumber(java.lang.String name)
+        {
+            java.lang.Integer number = fieldMap.get(name);
+            return number == null ? 0 : number.intValue();
+        }
+        private static final java.util.HashMap<java.lang.String,java.lang.Integer> fieldMap = new java.util.HashMap<java.lang.String,java.lang.Integer>();
+        static
+        {
+            fieldMap.put("groupNameFilter", 1);
         }
     }
 


### PR DESCRIPTION
This was done to make the API of packet retrieval consistent
with that of parameters, and also to make it possible to add
future conditions to any replay type.

Previous API in proto file is marked deprecated. Unfortunately
protoc 2.3.0 does not generate @Deprecated annotations. Code comments
were added where multiple API versions are still supported.

Also in this commit:
- the CliPacketDump was fixed. It did not work due to some small bugs
- while the .proto file stated that requesting all containers is
  possible by not specifying a filter, in practice it did not seem to
  work. So this got fixed as well (taking privileges into account).
