### PR TITLE
Fixes "Infinite" amongst others

### DIFF
--- a/yamcs-core/bin/setlibrarypath.sh
+++ b/yamcs-core/bin/setlibrarypath.sh
@@ -1,6 +1,6 @@
-for d in /usr/lib /usr/lib64 /usr/local/lib /usr/local/lib64;
+for d in /usr/lib /usr/lib64 /usr/local/lib /usr/local/lib64 /opt/local/lib;
 do 
-   if [ -e $d/libjtokyocabinet.so ];
+   if [ -e $d/libjtokyocabinet.so ] || [ -e $d/libjtokyocabinet.dylib ];
    then
       JAVA_LIBRARY_PATH=$JAVA_LIBRARY_PATH:$d   
    fi

--- a/yamcs-core/src/main/java/org/yamcs/ParameterValue.java
+++ b/yamcs-core/src/main/java/org/yamcs/ParameterValue.java
@@ -324,25 +324,35 @@ public class ParameterValue {
         gpvb.setGenerationTimeUTC(TimeEncoding.toString(getGenerationTime()));
 
         // TODO make this optional
-        if (getWatchRange() != null) {
-            gpvb.setWatchLow(getWatchRange().getMinInclusive());
-            gpvb.setWatchHigh(getWatchRange().getMaxInclusive());
+        if (watchRange != null) {
+            if (!Double.isInfinite(watchRange.getMinInclusive()))
+                gpvb.setWatchLow(watchRange.getMinInclusive());
+            if (!Double.isInfinite(watchRange.getMaxInclusive()))
+                gpvb.setWatchHigh(watchRange.getMaxInclusive());
         }
-        if (getWarningRange() != null) {
-            gpvb.setWarningLow(getWarningRange().getMinInclusive());
-            gpvb.setWarningHigh(getWarningRange().getMaxInclusive());
+        if (warningRange != null) {
+            if (!Double.isInfinite(warningRange.getMinInclusive()))
+                gpvb.setWarningLow(warningRange.getMinInclusive());
+            if (!Double.isInfinite(warningRange.getMaxInclusive()))
+                gpvb.setWarningHigh(warningRange.getMaxInclusive());
         }
-        if(getDistressRange() != null) {
-            gpvb.setDistressLow(getDistressRange().getMinInclusive());
-            gpvb.setDistressHigh(getDistressRange().getMaxInclusive());
+        if(distressRange != null) {
+            if (!Double.isInfinite(distressRange.getMinInclusive()))
+                gpvb.setDistressLow(distressRange.getMinInclusive());
+            if (!Double.isInfinite(distressRange.getMaxInclusive()))
+                gpvb.setDistressHigh(distressRange.getMaxInclusive());
         }
-        if(getCriticalRange() != null) {
-            gpvb.setCriticalLow(getCriticalRange().getMinInclusive());
-            gpvb.setCriticalLow(getCriticalRange().getMaxInclusive());
+        if(criticalRange != null) {
+            if (!Double.isInfinite(criticalRange.getMinInclusive()))
+                gpvb.setCriticalLow(criticalRange.getMinInclusive());
+            if (!Double.isInfinite(criticalRange.getMaxInclusive()))
+                gpvb.setCriticalHigh(criticalRange.getMaxInclusive());
         }
-        if(getSevereRange()!=null) {
-            gpvb.setSevereLow(getSevereRange().getMinInclusive());
-            gpvb.setSevereLow(getSevereRange().getMaxInclusive());
+        if(severeRange!=null) {
+            if (!Double.isInfinite(severeRange.getMinInclusive()))
+                gpvb.setSevereLow(severeRange.getMinInclusive());
+            if (!Double.isInfinite(severeRange.getMaxInclusive()))
+                gpvb.setSevereHigh(severeRange.getMaxInclusive());
         }
         
         if(id!=null) gpvb.setId(id);

--- a/yamcs-web/src/main/java/org/yamcs/web/rest/AbstractRestRequestHandler.java
+++ b/yamcs-web/src/main/java/org/yamcs/web/rest/AbstractRestRequestHandler.java
@@ -190,7 +190,7 @@ public abstract class AbstractRestRequestHandler extends AbstractRequestHandler 
         JsonGenerator generator = jsonFactory.createJsonGenerator(out, JsonEncoding.UTF8);
         if (qsDecoder.getParameters().containsKey("pretty")) {
             List<String> pretty = qsDecoder.getParameters().get("pretty");
-            if (pretty == null || Boolean.parseBoolean(pretty.get(0))) {
+            if (pretty == null || pretty.isEmpty() || Boolean.parseBoolean(pretty.get(0))) {
                 generator.useDefaultPrettyPrinter();
             }
         }

--- a/yamcs-web/src/main/java/org/yamcs/web/rest/MdbRequestHandler.java
+++ b/yamcs-web/src/main/java/org/yamcs/web/rest/MdbRequestHandler.java
@@ -2,6 +2,7 @@ package org.yamcs.web.rest;
 
 import java.io.IOException;
 import java.io.ObjectOutputStream;
+import java.util.Map.Entry;
 
 import org.jboss.netty.channel.ChannelHandlerContext;
 import org.jboss.netty.channel.MessageEvent;
@@ -17,7 +18,6 @@ import org.yamcs.protobuf.Rest.RestListAvailableParametersRequest;
 import org.yamcs.protobuf.Rest.RestListAvailableParametersResponse;
 import org.yamcs.protobuf.SchemaRest;
 import org.yamcs.protobuf.Yamcs.NamedObjectId;
-import org.yamcs.xtce.NamedDescriptionIndex;
 import org.yamcs.xtce.Parameter;
 import org.yamcs.xtce.XtceDb;
 import org.yamcs.xtceproc.XtceDbFactory;
@@ -49,18 +49,24 @@ public class MdbRequestHandler extends AbstractRestRequestHandler {
 
     /**
      * Sends the XTCEDB for the requested yamcs instance.
-     * <p>
-     * Currently only sends MDB:OPS Name names.
      */
     private RestListAvailableParametersResponse listAvailableParameters(RestListAvailableParametersRequest request, String yamcsInstance) throws RestException {
         XtceDb mdb = loadMdb(yamcsInstance);
         RestListAvailableParametersResponse.Builder responseb = RestListAvailableParametersResponse.newBuilder();
-
-        NamedDescriptionIndex<Parameter> index = mdb.getParameterAliases();
-        // TODO dump for all namespaces if not specified
-        for (String namespace : request.getNamespacesList()) {
-            for (String name : index.getNamesForAlias(namespace)) {
-                responseb.addIds(NamedObjectId.newBuilder().setNamespace(namespace).setName(name));
+        if (request.getNamespacesCount() == 0) { // Send all, if no namespace specified
+            for(Parameter parameter : mdb.getParameters()) {
+                for (Entry<String,String> entry : parameter.getAliasSet().getAliases().entrySet()) {
+                    responseb.addIds(NamedObjectId.newBuilder().setNamespace(entry.getKey()).setName(entry.getValue()));
+                }
+            }
+        } else {
+            for (Parameter p : mdb.getParameters()) {
+                for (String namespace : request.getNamespacesList()) {
+                    String alias = p.getAlias(namespace);
+                    if (alias != null) {
+                        responseb.addIds(NamedObjectId.newBuilder().setNamespace(namespace).setName(alias));
+                    }
+                }
             }
         }
         return responseb.build();

--- a/yamcs-xtce/src/main/java/org/yamcs/xtce/NamedDescriptionIndex.java
+++ b/yamcs-xtce/src/main/java/org/yamcs/xtce/NamedDescriptionIndex.java
@@ -3,11 +3,9 @@ package org.yamcs.xtce;
 
 import java.io.Serializable;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.Set;
 
 import org.yamcs.xtce.xml.XtceAliasSet;
 
@@ -73,16 +71,6 @@ public class NamedDescriptionIndex<T extends NameDescription> implements Seriali
      */
     public Collection<T> getObjects() {
         return index.values();
-    }
-
-    /**
-     * Returns a set with all names under a particular alias namespace.
-     */
-    public Set<String> getNamesForAlias(String namespace) {
-        if (!aliasIndex.containsKey(namespace)) {
-            return Collections.emptySet();
-        }
-        return aliasIndex.get(namespace).keySet();
     }
 
     /**

--- a/yamcs-xtce/src/main/java/org/yamcs/xtce/xml/XtceAliasSet.java
+++ b/yamcs-xtce/src/main/java/org/yamcs/xtce/xml/XtceAliasSet.java
@@ -1,7 +1,9 @@
 package org.yamcs.xtce.xml;
 
 import java.io.Serializable;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -52,7 +54,14 @@ public class XtceAliasSet implements Serializable {
     public Set<String> getNamespaces() {
         return aliases.keySet();
     }
-    
+
+    /**
+     * Returns a readonly map, mapping namespace to alias
+     */
+    public Map<String, String> getAliases() {
+        return Collections.unmodifiableMap(aliases);
+    }
+
     public int size() {
         return aliases.size();
     }


### PR DESCRIPTION
Since the mininclusive/maxinclusive are optional primitives, we can just not fill them in. Clients should use the has-functions, or use wrappers.