### PR TITLE
rest: processor request handler didn't respond

### DIFF
--- a/yamcs-api/src/main/java/org/yamcs/protobuf/Rest.java
+++ b/yamcs-api/src/main/java/org/yamcs/protobuf/Rest.java
@@ -7355,6 +7355,315 @@ public final class Rest {
     // @@protoc_insertion_point(class_scope:rest.RestConnectToProcessorResponse)
   }
 
+  public interface RestProcessorResponseOrBuilder
+      extends com.google.protobuf.MessageOrBuilder {
+  }
+  /**
+   * Protobuf type {@code rest.RestProcessorResponse}
+   */
+  public static final class RestProcessorResponse extends
+      com.google.protobuf.GeneratedMessage
+      implements RestProcessorResponseOrBuilder {
+    // Use RestProcessorResponse.newBuilder() to construct.
+    private RestProcessorResponse(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+      super(builder);
+      this.unknownFields = builder.getUnknownFields();
+    }
+    private RestProcessorResponse(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
+
+    private static final RestProcessorResponse defaultInstance;
+    public static RestProcessorResponse getDefaultInstance() {
+      return defaultInstance;
+    }
+
+    public RestProcessorResponse getDefaultInstanceForType() {
+      return defaultInstance;
+    }
+
+    private final com.google.protobuf.UnknownFieldSet unknownFields;
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+        getUnknownFields() {
+      return this.unknownFields;
+    }
+    private RestProcessorResponse(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      initFields();
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            default: {
+              if (!parseUnknownField(input, unknownFields,
+                                     extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e.getMessage()).setUnfinishedMessage(this);
+      } finally {
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return org.yamcs.protobuf.Rest.internal_static_rest_RestProcessorResponse_descriptor;
+    }
+
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return org.yamcs.protobuf.Rest.internal_static_rest_RestProcessorResponse_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              org.yamcs.protobuf.Rest.RestProcessorResponse.class, org.yamcs.protobuf.Rest.RestProcessorResponse.Builder.class);
+    }
+
+    public static com.google.protobuf.Parser<RestProcessorResponse> PARSER =
+        new com.google.protobuf.AbstractParser<RestProcessorResponse>() {
+      public RestProcessorResponse parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new RestProcessorResponse(input, extensionRegistry);
+      }
+    };
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<RestProcessorResponse> getParserForType() {
+      return PARSER;
+    }
+
+    private void initFields() {
+    }
+    private byte memoizedIsInitialized = -1;
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized != -1) return isInitialized == 1;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      getSerializedSize();
+      getUnknownFields().writeTo(output);
+    }
+
+    private int memoizedSerializedSize = -1;
+    public int getSerializedSize() {
+      int size = memoizedSerializedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      size += getUnknownFields().getSerializedSize();
+      memoizedSerializedSize = size;
+      return size;
+    }
+
+    private static final long serialVersionUID = 0L;
+    @java.lang.Override
+    protected java.lang.Object writeReplace()
+        throws java.io.ObjectStreamException {
+      return super.writeReplace();
+    }
+
+    public static org.yamcs.protobuf.Rest.RestProcessorResponse parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static org.yamcs.protobuf.Rest.RestProcessorResponse parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static org.yamcs.protobuf.Rest.RestProcessorResponse parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static org.yamcs.protobuf.Rest.RestProcessorResponse parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static org.yamcs.protobuf.Rest.RestProcessorResponse parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static org.yamcs.protobuf.Rest.RestProcessorResponse parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+    public static org.yamcs.protobuf.Rest.RestProcessorResponse parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input);
+    }
+    public static org.yamcs.protobuf.Rest.RestProcessorResponse parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+    }
+    public static org.yamcs.protobuf.Rest.RestProcessorResponse parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static org.yamcs.protobuf.Rest.RestProcessorResponse parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+
+    public static Builder newBuilder() { return Builder.create(); }
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder(org.yamcs.protobuf.Rest.RestProcessorResponse prototype) {
+      return newBuilder().mergeFrom(prototype);
+    }
+    public Builder toBuilder() { return newBuilder(this); }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code rest.RestProcessorResponse}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessage.Builder<Builder>
+       implements org.yamcs.protobuf.Rest.RestProcessorResponseOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return org.yamcs.protobuf.Rest.internal_static_rest_RestProcessorResponse_descriptor;
+      }
+
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return org.yamcs.protobuf.Rest.internal_static_rest_RestProcessorResponse_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                org.yamcs.protobuf.Rest.RestProcessorResponse.class, org.yamcs.protobuf.Rest.RestProcessorResponse.Builder.class);
+      }
+
+      // Construct using org.yamcs.protobuf.Rest.RestProcessorResponse.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+        }
+      }
+      private static Builder create() {
+        return new Builder();
+      }
+
+      public Builder clear() {
+        super.clear();
+        return this;
+      }
+
+      public Builder clone() {
+        return create().mergeFrom(buildPartial());
+      }
+
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return org.yamcs.protobuf.Rest.internal_static_rest_RestProcessorResponse_descriptor;
+      }
+
+      public org.yamcs.protobuf.Rest.RestProcessorResponse getDefaultInstanceForType() {
+        return org.yamcs.protobuf.Rest.RestProcessorResponse.getDefaultInstance();
+      }
+
+      public org.yamcs.protobuf.Rest.RestProcessorResponse build() {
+        org.yamcs.protobuf.Rest.RestProcessorResponse result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      public org.yamcs.protobuf.Rest.RestProcessorResponse buildPartial() {
+        org.yamcs.protobuf.Rest.RestProcessorResponse result = new org.yamcs.protobuf.Rest.RestProcessorResponse(this);
+        onBuilt();
+        return result;
+      }
+
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof org.yamcs.protobuf.Rest.RestProcessorResponse) {
+          return mergeFrom((org.yamcs.protobuf.Rest.RestProcessorResponse)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(org.yamcs.protobuf.Rest.RestProcessorResponse other) {
+        if (other == org.yamcs.protobuf.Rest.RestProcessorResponse.getDefaultInstance()) return this;
+        this.mergeUnknownFields(other.getUnknownFields());
+        return this;
+      }
+
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        org.yamcs.protobuf.Rest.RestProcessorResponse parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (org.yamcs.protobuf.Rest.RestProcessorResponse) e.getUnfinishedMessage();
+          throw e;
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+
+      // @@protoc_insertion_point(builder_scope:rest.RestProcessorResponse)
+    }
+
+    static {
+      defaultInstance = new RestProcessorResponse(true);
+      defaultInstance.initFields();
+    }
+
+    // @@protoc_insertion_point(class_scope:rest.RestProcessorResponse)
+  }
+
   public interface RestGetParameterRequestOrBuilder
       extends com.google.protobuf.MessageOrBuilder {
 
@@ -13531,6 +13840,11 @@ public final class Rest {
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_rest_RestConnectToProcessorResponse_fieldAccessorTable;
   private static com.google.protobuf.Descriptors.Descriptor
+    internal_static_rest_RestProcessorResponse_descriptor;
+  private static
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      internal_static_rest_RestProcessorResponse_fieldAccessorTable;
+  private static com.google.protobuf.Descriptors.Descriptor
     internal_static_rest_RestGetParameterRequest_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
@@ -13585,40 +13899,41 @@ public final class Rest {
       "t\"(\n\026RestDumpRawMdbResponse\022\016\n\006rawMdb\030\002 " +
       "\001(\014\"\032\n\030RestSetParameterResponse\"\035\n\033RestC",
       "reateProcessorResponse\" \n\036RestConnectToP" +
-      "rocessorResponse\"a\n\027RestGetParameterRequ" +
-      "est\022\"\n\004list\030\001 \003(\0132\024.yamcs.NamedObjectId\022" +
-      "\021\n\tfromCache\030\002 \001(\010\022\017\n\007timeout\030\003 \001(\004\"\363\002\n\026" +
-      "RestDumpArchiveRequest\022\r\n\005start\030\001 \001(\003\022\014\n" +
-      "\004stop\030\002 \001(\003\022\020\n\010utcStart\030\t \001(\t\022\017\n\007utcStop" +
-      "\030\n \001(\t\0227\n\020parameterRequest\030\003 \001(\0132\035.yamcs" +
-      ".ParameterReplayRequest\0221\n\rpacketRequest" +
-      "\030\004 \001(\0132\032.yamcs.PacketReplayRequest\022/\n\014ev" +
-      "entRequest\030\005 \001(\0132\031.yamcs.EventReplayRequ",
-      "est\022A\n\025commandHistoryRequest\030\006 \001(\0132\".yam" +
-      "cs.CommandHistoryReplayRequest\022)\n\tppRequ" +
-      "est\030\007 \001(\0132\026.yamcs.PpReplayRequest\022\016\n\006str" +
-      "eam\030\010 \001(\010\"\346\001\n\027RestDumpArchiveResponse\022,\n" +
-      "\rparameterData\030\002 \003(\0132\025.pvalue.ParameterD" +
-      "ata\022\'\n\npacketData\030\003 \003(\0132\023.yamcs.TmPacket" +
-      "Data\0220\n\007command\030\004 \003(\0132\037.commanding.Comma" +
-      "ndHistoryEntry\022\033\n\005event\030\005 \003(\0132\014.yamcs.Ev" +
-      "ent\022%\n\006ppData\030\006 \003(\0132\025.pvalue.ParameterDa" +
-      "ta\"A\n\026RestSendCommandRequest\022\'\n\010commands",
-      "\030\001 \003(\0132\025.rest.RestCommandType\"\031\n\027RestSen" +
-      "dCommandResponse*G\n\016RestDataSource\022\017\n\013TE" +
-      "LEMETERED\020\000\022\013\n\007DERIVED\020\001\022\014\n\010CONSTANT\020\002\022\t" +
-      "\n\005LOCAL\020\0032\266\003\n\013RESTService\022n\n\027listAvailab" +
-      "leParameters\022(.rest.RestListAvailablePar" +
-      "ametersRequest\032).rest.RestListAvailableP" +
-      "arametersResponse\022V\n\017validateCommand\022 .r" +
-      "est.RestValidateCommandRequest\032!.rest.Re" +
-      "stValidateCommandResponse\022J\n\013sendCommand" +
-      "\022\034.rest.RestSendCommandRequest\032\035.rest.Re",
-      "stSendCommandResponse\022G\n\ndumpRawMdb\022\033.re" +
-      "st.RestDumpRawMdbRequest\032\034.rest.RestDump" +
-      "RawMdbResponse\022J\n\013dumpArchive\022\034.rest.Res" +
-      "tDumpArchiveRequest\032\035.rest.RestDumpArchi" +
-      "veResponseB\024\n\022org.yamcs.protobuf"
+      "rocessorResponse\"\027\n\025RestProcessorRespons" +
+      "e\"a\n\027RestGetParameterRequest\022\"\n\004list\030\001 \003" +
+      "(\0132\024.yamcs.NamedObjectId\022\021\n\tfromCache\030\002 " +
+      "\001(\010\022\017\n\007timeout\030\003 \001(\004\"\363\002\n\026RestDumpArchive" +
+      "Request\022\r\n\005start\030\001 \001(\003\022\014\n\004stop\030\002 \001(\003\022\020\n\010" +
+      "utcStart\030\t \001(\t\022\017\n\007utcStop\030\n \001(\t\0227\n\020param" +
+      "eterRequest\030\003 \001(\0132\035.yamcs.ParameterRepla" +
+      "yRequest\0221\n\rpacketRequest\030\004 \001(\0132\032.yamcs." +
+      "PacketReplayRequest\022/\n\014eventRequest\030\005 \001(",
+      "\0132\031.yamcs.EventReplayRequest\022A\n\025commandH" +
+      "istoryRequest\030\006 \001(\0132\".yamcs.CommandHisto" +
+      "ryReplayRequest\022)\n\tppRequest\030\007 \001(\0132\026.yam" +
+      "cs.PpReplayRequest\022\016\n\006stream\030\010 \001(\010\"\346\001\n\027R" +
+      "estDumpArchiveResponse\022,\n\rparameterData\030" +
+      "\002 \003(\0132\025.pvalue.ParameterData\022\'\n\npacketDa" +
+      "ta\030\003 \003(\0132\023.yamcs.TmPacketData\0220\n\007command" +
+      "\030\004 \003(\0132\037.commanding.CommandHistoryEntry\022" +
+      "\033\n\005event\030\005 \003(\0132\014.yamcs.Event\022%\n\006ppData\030\006" +
+      " \003(\0132\025.pvalue.ParameterData\"A\n\026RestSendC",
+      "ommandRequest\022\'\n\010commands\030\001 \003(\0132\025.rest.R" +
+      "estCommandType\"\031\n\027RestSendCommandRespons" +
+      "e*G\n\016RestDataSource\022\017\n\013TELEMETERED\020\000\022\013\n\007" +
+      "DERIVED\020\001\022\014\n\010CONSTANT\020\002\022\t\n\005LOCAL\020\0032\266\003\n\013R" +
+      "ESTService\022n\n\027listAvailableParameters\022(." +
+      "rest.RestListAvailableParametersRequest\032" +
+      ").rest.RestListAvailableParametersRespon" +
+      "se\022V\n\017validateCommand\022 .rest.RestValidat" +
+      "eCommandRequest\032!.rest.RestValidateComma" +
+      "ndResponse\022J\n\013sendCommand\022\034.rest.RestSen",
+      "dCommandRequest\032\035.rest.RestSendCommandRe" +
+      "sponse\022G\n\ndumpRawMdb\022\033.rest.RestDumpRawM" +
+      "dbRequest\032\034.rest.RestDumpRawMdbResponse\022" +
+      "J\n\013dumpArchive\022\034.rest.RestDumpArchiveReq" +
+      "uest\032\035.rest.RestDumpArchiveResponseB\024\n\022o" +
+      "rg.yamcs.protobuf"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
       new com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner() {
@@ -13703,32 +14018,38 @@ public final class Rest {
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_rest_RestConnectToProcessorResponse_descriptor,
               new java.lang.String[] { });
-          internal_static_rest_RestGetParameterRequest_descriptor =
+          internal_static_rest_RestProcessorResponse_descriptor =
             getDescriptor().getMessageTypes().get(13);
+          internal_static_rest_RestProcessorResponse_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_rest_RestProcessorResponse_descriptor,
+              new java.lang.String[] { });
+          internal_static_rest_RestGetParameterRequest_descriptor =
+            getDescriptor().getMessageTypes().get(14);
           internal_static_rest_RestGetParameterRequest_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_rest_RestGetParameterRequest_descriptor,
               new java.lang.String[] { "List", "FromCache", "Timeout", });
           internal_static_rest_RestDumpArchiveRequest_descriptor =
-            getDescriptor().getMessageTypes().get(14);
+            getDescriptor().getMessageTypes().get(15);
           internal_static_rest_RestDumpArchiveRequest_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_rest_RestDumpArchiveRequest_descriptor,
               new java.lang.String[] { "Start", "Stop", "UtcStart", "UtcStop", "ParameterRequest", "PacketRequest", "EventRequest", "CommandHistoryRequest", "PpRequest", "Stream", });
           internal_static_rest_RestDumpArchiveResponse_descriptor =
-            getDescriptor().getMessageTypes().get(15);
+            getDescriptor().getMessageTypes().get(16);
           internal_static_rest_RestDumpArchiveResponse_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_rest_RestDumpArchiveResponse_descriptor,
               new java.lang.String[] { "ParameterData", "PacketData", "Command", "Event", "PpData", });
           internal_static_rest_RestSendCommandRequest_descriptor =
-            getDescriptor().getMessageTypes().get(16);
+            getDescriptor().getMessageTypes().get(17);
           internal_static_rest_RestSendCommandRequest_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_rest_RestSendCommandRequest_descriptor,
               new java.lang.String[] { "Commands", });
           internal_static_rest_RestSendCommandResponse_descriptor =
-            getDescriptor().getMessageTypes().get(17);
+            getDescriptor().getMessageTypes().get(18);
           internal_static_rest_RestSendCommandResponse_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_rest_RestSendCommandResponse_descriptor,

--- a/yamcs-api/src/main/java/org/yamcs/protobuf/SchemaRest.java
+++ b/yamcs-api/src/main/java/org/yamcs/protobuf/SchemaRest.java
@@ -1477,6 +1477,110 @@ public final class SchemaRest
         }
     }
 
+    public static final class RestProcessorResponse
+    {
+        public static final org.yamcs.protobuf.SchemaRest.RestProcessorResponse.MessageSchema WRITE =
+            new org.yamcs.protobuf.SchemaRest.RestProcessorResponse.MessageSchema();
+        public static final org.yamcs.protobuf.SchemaRest.RestProcessorResponse.BuilderSchema MERGE =
+            new org.yamcs.protobuf.SchemaRest.RestProcessorResponse.BuilderSchema();
+        
+        public static class MessageSchema implements io.protostuff.Schema<org.yamcs.protobuf.Rest.RestProcessorResponse>
+        {
+            public void writeTo(io.protostuff.Output output, org.yamcs.protobuf.Rest.RestProcessorResponse message) throws java.io.IOException
+            {
+            }
+            public boolean isInitialized(org.yamcs.protobuf.Rest.RestProcessorResponse message)
+            {
+                return message.isInitialized();
+            }
+            public java.lang.String getFieldName(int number)
+            {
+                return org.yamcs.protobuf.SchemaRest.RestProcessorResponse.getFieldName(number);
+            }
+            public int getFieldNumber(java.lang.String name)
+            {
+                return org.yamcs.protobuf.SchemaRest.RestProcessorResponse.getFieldNumber(name);
+            }
+            public java.lang.Class<org.yamcs.protobuf.Rest.RestProcessorResponse> typeClass()
+            {
+                return org.yamcs.protobuf.Rest.RestProcessorResponse.class;
+            }
+            public java.lang.String messageName()
+            {
+                return org.yamcs.protobuf.Rest.RestProcessorResponse.class.getSimpleName();
+            }
+            public java.lang.String messageFullName()
+            {
+                return org.yamcs.protobuf.Rest.RestProcessorResponse.class.getName();
+            }
+            //unused
+            public void mergeFrom(io.protostuff.Input input, org.yamcs.protobuf.Rest.RestProcessorResponse message) throws java.io.IOException {}
+            public org.yamcs.protobuf.Rest.RestProcessorResponse newMessage() { return null; }
+        }
+        public static class BuilderSchema implements io.protostuff.Schema<org.yamcs.protobuf.Rest.RestProcessorResponse.Builder>
+        {
+            public void mergeFrom(io.protostuff.Input input, org.yamcs.protobuf.Rest.RestProcessorResponse.Builder builder) throws java.io.IOException
+            {
+                for(int number = input.readFieldNumber(this);; number = input.readFieldNumber(this))
+                {
+                    switch(number)
+                    {
+                        case 0:
+                            return;
+                        default:
+                            input.handleUnknownField(number, this);
+                    }
+                }
+            }
+            public boolean isInitialized(org.yamcs.protobuf.Rest.RestProcessorResponse.Builder builder)
+            {
+                return builder.isInitialized();
+            }
+            public org.yamcs.protobuf.Rest.RestProcessorResponse.Builder newMessage()
+            {
+                return org.yamcs.protobuf.Rest.RestProcessorResponse.newBuilder();
+            }
+            public java.lang.String getFieldName(int number)
+            {
+                return org.yamcs.protobuf.SchemaRest.RestProcessorResponse.getFieldName(number);
+            }
+            public int getFieldNumber(java.lang.String name)
+            {
+                return org.yamcs.protobuf.SchemaRest.RestProcessorResponse.getFieldNumber(name);
+            }
+            public java.lang.Class<org.yamcs.protobuf.Rest.RestProcessorResponse.Builder> typeClass()
+            {
+                return org.yamcs.protobuf.Rest.RestProcessorResponse.Builder.class;
+            }
+            public java.lang.String messageName()
+            {
+                return org.yamcs.protobuf.Rest.RestProcessorResponse.class.getSimpleName();
+            }
+            public java.lang.String messageFullName()
+            {
+                return org.yamcs.protobuf.Rest.RestProcessorResponse.class.getName();
+            }
+            //unused
+            public void writeTo(io.protostuff.Output output, org.yamcs.protobuf.Rest.RestProcessorResponse.Builder builder) throws java.io.IOException {}
+        }
+        public static java.lang.String getFieldName(int number)
+        {
+            switch(number)
+            {
+                default: return null;
+            }
+        }
+        public static int getFieldNumber(java.lang.String name)
+        {
+            java.lang.Integer number = fieldMap.get(name);
+            return number == null ? 0 : number.intValue();
+        }
+        private static final java.util.HashMap<java.lang.String,java.lang.Integer> fieldMap = new java.util.HashMap<java.lang.String,java.lang.Integer>();
+        static
+        {
+        }
+    }
+
     public static final class RestGetParameterRequest
     {
         public static final org.yamcs.protobuf.SchemaRest.RestGetParameterRequest.MessageSchema WRITE =

--- a/yamcs-api/src/main/rest.proto
+++ b/yamcs-api/src/main/rest.proto
@@ -66,6 +66,9 @@ message RestCreateProcessorResponse {
 message RestConnectToProcessorResponse {
 }
 
+message RestProcessorResponse {
+}
+
 message RestGetParameterRequest {
     repeated yamcs.NamedObjectId list=1;
     optional bool fromCache=2;

--- a/yamcs-core/src/main/java/org/yamcs/web/rest/ApiRequestHandler.java
+++ b/yamcs-core/src/main/java/org/yamcs/web/rest/ApiRequestHandler.java
@@ -11,7 +11,7 @@ import org.yamcs.security.AuthenticationToken;
 
 /**
  * Handles everything under /api. In the future could also be used to handle multiple versions,
- * if every needed. (e.g. /api/v2).
+ * if ever needed. (e.g. /api/v2).
  */
 public class ApiRequestHandler extends AbstractRestRequestHandler {
 

--- a/yamcs-core/src/main/java/org/yamcs/web/rest/ManagementRequestHandler.java
+++ b/yamcs-core/src/main/java/org/yamcs/web/rest/ManagementRequestHandler.java
@@ -19,7 +19,7 @@ import org.yamcs.security.AuthenticationToken;
 import org.yamcs.security.Privilege;
 
 public class ManagementRequestHandler extends AbstractRestRequestHandler {
-    private static final Logger log = LoggerFactory.getLogger(ArchiveRequestHandler.class.getName());
+    private static final Logger log = LoggerFactory.getLogger(ManagementRequestHandler.class.getName());
     
     
     public void handleRequest(ChannelHandlerContext ctx, FullHttpRequest req, String yamcsInstance, String remainingUri, AuthenticationToken authToken) throws RestException {

--- a/yamcs-core/src/main/java/org/yamcs/web/rest/ProcessorRequestHandler.java
+++ b/yamcs-core/src/main/java/org/yamcs/web/rest/ProcessorRequestHandler.java
@@ -4,40 +4,44 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.QueryStringDecoder;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.yamcs.YProcessor;
 import org.yamcs.YamcsException;
 import org.yamcs.management.ManagementService;
+import org.yamcs.protobuf.Rest.RestConnectToProcessorResponse;
+import org.yamcs.protobuf.Rest.RestCreateProcessorResponse;
+import org.yamcs.protobuf.Rest.RestProcessorResponse;
+import org.yamcs.protobuf.SchemaRest;
 import org.yamcs.protobuf.SchemaYamcsManagement;
 import org.yamcs.protobuf.YamcsManagement.ProcessorManagementRequest;
 import org.yamcs.protobuf.YamcsManagement.ProcessorRequest;
 import org.yamcs.security.AuthenticationToken;
+import org.yamcs.security.Privilege;
 
 public class ProcessorRequestHandler extends AbstractRestRequestHandler {
     private static final Logger log = LoggerFactory.getLogger(ProcessorRequestHandler.class.getName());
     
     
     public void handleRequest(ChannelHandlerContext ctx, FullHttpRequest req, String yamcsInstance, String remainingUri, AuthenticationToken authToken) throws RestException {
-        String[] path = remainingUri.split("/", 2);
-        
-        if (path.length == 0) {
-            handleProcessorManagementRequest(ctx, req, yamcsInstance, authToken);
+        QueryStringDecoder qsDecoder = new QueryStringDecoder(remainingUri);
+        if ("".equals(qsDecoder.path())) {
+            handleProcessorManagementRequest(ctx, req, yamcsInstance, qsDecoder, authToken);
         } else {
-            String yprocName = path[0];
+            String yprocName = remainingUri.split("/")[0];
             YProcessor yproc = YProcessor.getInstance(yamcsInstance, yprocName);
             if(yproc==null) {
                 log.warn("Sending NOT_FOUND because invalid processor name '{}' has been requested", yprocName);
                 sendError(ctx, HttpResponseStatus.NOT_FOUND);
                 return;
             }
-            remainingUri = remainingUri.substring(path.length > 1 ? path[0].length() + 1 : path[0].length());
-            handleProcessorRequest(ctx, req, yproc, remainingUri);
+            handleProcessorRequest(ctx, req, yproc, qsDecoder);
         }
     }
         
-    private void handleProcessorRequest(ChannelHandlerContext ctx, FullHttpRequest req, YProcessor yproc, String remainingUri) throws RestException {
+    private void handleProcessorRequest(ChannelHandlerContext ctx, FullHttpRequest req, YProcessor yproc, QueryStringDecoder qsDecoder) throws RestException {
         ProcessorRequest yprocReq = readMessage(req, SchemaYamcsManagement.ProcessorRequest.MERGE).build();
         if(req.getMethod()==HttpMethod.POST) {
             switch(yprocReq.getOperation()) {
@@ -65,10 +69,12 @@ public class ProcessorRequestHandler extends AbstractRestRequestHandler {
             default:
                 throw new BadRequestException("Invalid operation "+yprocReq.getOperation()+" specified");
             }
+            RestProcessorResponse response = RestProcessorResponse.newBuilder().build();
+            writeMessage(ctx, req, qsDecoder, response, SchemaRest.RestProcessorResponse.WRITE);
         }
     }
     
-    private void handleProcessorManagementRequest(ChannelHandlerContext ctx, FullHttpRequest req, String yamcsInstance, AuthenticationToken authToken) throws RestException {
+    private void handleProcessorManagementRequest(ChannelHandlerContext ctx, FullHttpRequest req, String yamcsInstance, QueryStringDecoder qsDecoder, AuthenticationToken authToken) throws RestException {
         ProcessorManagementRequest yprocReq = readMessage(req, SchemaYamcsManagement.ProcessorManagementRequest.MERGE).build();
         if(req.getMethod()==HttpMethod.POST) {
             switch(yprocReq.getOperation()) {
@@ -76,6 +82,8 @@ public class ProcessorRequestHandler extends AbstractRestRequestHandler {
                 ManagementService mservice = ManagementService.getInstance();
                 try {
                     mservice.connectToProcessor(yprocReq, authToken);
+                    RestConnectToProcessorResponse response = RestConnectToProcessorResponse.newBuilder().build();
+                    writeMessage(ctx, req, qsDecoder, response, SchemaRest.RestConnectToProcessorResponse.WRITE);
                 } catch (YamcsException e) {
                     throw new BadRequestException(e.getMessage());
                 }
@@ -85,6 +93,8 @@ public class ProcessorRequestHandler extends AbstractRestRequestHandler {
                 mservice = ManagementService.getInstance();
                 try {
                     mservice.createProcessor(yprocReq, authToken);
+                    RestCreateProcessorResponse response = RestCreateProcessorResponse.newBuilder().build();
+                    writeMessage(ctx, req, qsDecoder, response, SchemaRest.RestCreateProcessorResponse.WRITE);
                 } catch (YamcsException e) {
                     throw new BadRequestException(e.getMessage());
                 }

--- a/yamcs-core/src/main/java/org/yamcs/web/rest/ProcessorRequestHandler.java
+++ b/yamcs-core/src/main/java/org/yamcs/web/rest/ProcessorRequestHandler.java
@@ -23,27 +23,17 @@ public class ProcessorRequestHandler extends AbstractRestRequestHandler {
         String[] path = remainingUri.split("/", 2);
         
         if (path.length == 0) {
-            sendError(ctx, HttpResponseStatus.NOT_FOUND);
-            return;
-        }
-        if("processor".equals(path[0])) {
-            if (path.length == 1) {
-                handleProcessorManagementRequest(ctx, req, yamcsInstance, authToken);
-            } else {
-                String yprocName = path[1];
-                YProcessor yproc = YProcessor.getInstance(yamcsInstance, yprocName);
-                if(yproc==null) {
-                    log.warn("Sending NOT_FOUND because invalid processor name '{}' has been requested", yprocName);
-                    sendError(ctx, HttpResponseStatus.NOT_FOUND);
-                    return;
-                }
-                remainingUri = remainingUri.substring(path.length > 1 ? path[0].length() + 1 : path[0].length());
-                handleProcessorRequest(ctx, req, yproc, remainingUri);
-            }
+            handleProcessorManagementRequest(ctx, req, yamcsInstance, authToken);
         } else {
-            log.warn("Unknown request {} has been received");
-            sendError(ctx, HttpResponseStatus.NOT_FOUND);
-            return;
+            String yprocName = path[0];
+            YProcessor yproc = YProcessor.getInstance(yamcsInstance, yprocName);
+            if(yproc==null) {
+                log.warn("Sending NOT_FOUND because invalid processor name '{}' has been requested", yprocName);
+                sendError(ctx, HttpResponseStatus.NOT_FOUND);
+                return;
+            }
+            remainingUri = remainingUri.substring(path.length > 1 ? path[0].length() + 1 : path[0].length());
+            handleProcessorRequest(ctx, req, yproc, remainingUri);
         }
     }
         


### PR DESCRIPTION
creates yet another empty message. Should probably refactor this part of the api a bit later on.