### PR TITLE
Travis: Unit Tests / Integration Test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,6 @@ before_script:
  - tar xzvf tokyocabinet-java-1.24.tar.gz
  - cd tokyocabinet-java-1.24 && ./configure && make && sudo make install && cd ..
 
-script: mvn -Dsurefire.useFile=false test
+script: mvn -Dsurefire.useFile=false test && mvn -Dtest=IntegrationTest -pl yamcs-core test
 
 

--- a/yamcs-core/pom.xml
+++ b/yamcs-core/pom.xml
@@ -150,6 +150,9 @@
    		     <value>${project.build.directory}/test-classes/logging.properties</value>
    		   </property>
     </systemProperties>
+          <excludes>
+          <exclude>**/IntegrationTest.java</exclude>
+          </excludes>
         </configuration>
       </plugin>
       <plugin>

--- a/yamcs-core/src/test/resources/hornetq-configuration-secure.xml
+++ b/yamcs-core/src/test/resources/hornetq-configuration-secure.xml
@@ -7,10 +7,6 @@
     <security-invalidation-interval>60000</security-invalidation-interval>
     <journal-type>NIO</journal-type>
 
-    <bindings-directory>/storage/hornetq/bindings</bindings-directory>
-    <journal-directory>/storage/hornetq/journal</journal-directory>
-    <large-messages-directory>/storage/hornetq/large-messages</large-messages-directory>
-    <paging-directory>/storage/hornetq/paging</paging-directory>
 
 
     <management-notification-address>hornetq.notifications</management-notification-address>


### PR DESCRIPTION
In Travis build, run first the unit tests suite and then the integration test suite.
This allows to start a new JVM and load fresh configuration files for the integration tests.