### PR TITLE
make-client-package.sh: fix issue with sources jar

### DIFF
--- a/make-client-package.sh
+++ b/make-client-package.sh
@@ -4,7 +4,8 @@ cd `dirname $0`
 yamcshome=`pwd`
 
 unset GREP_OPTIONS
-yjar=`ls -t -1 yamcs-core/target/yamcs*.jar | head -n 1`
+# Get the latest yamcs-core/yamcs*.jar but exclude the sources jar because the client needs the compiled Java class files
+yjar=`ls -t -1 yamcs-core/target/yamcs*.jar | grep -v -- -sources.jar | head -n 1`
 dist=yamcs-client-`echo $yjar | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+'`
 version=`echo $yjar | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+'`
 


### PR DESCRIPTION
When there are multiple yamcs-core/yamcs*.jar files,
make-client-package.sh takes the latest one.

But if the latest one is a -sources jar, that one will be chosen
instead of the normal compiled jar file, which will result in a
ClassDefNotFoundException when starting the software because the
.class files are not in the -sources jar.

This commit fixes the issue by excluding the sources jar.