### PR TITLE
Rename event-decoder.yaml to *.sample

### DIFF
--- a/yamcs-core/etc/event-decoder.yaml.sample
+++ b/yamcs-core/etc/event-decoder.yaml.sample
@@ -1,7 +1,7 @@
 # Path to [ACES-EXCEL-DB] spreadsheet
-aces:
-    spreadsheet: /home/nm/aces/mdb/aces.xls
+#aces:
+#    spreadsheet: /home/nm/aces/mdb/aces.xls
 
 #Path to the directory containing the EDR monitoring tables montaux.txt, montnom.txt and montdsdb.txt
-edr:
-    montablesdir: /home/nm/workspace/yamcs-svn/yamcs-erasmus/src/config/
+#edr:
+#    montablesdir: /home/nm/workspace/yamcs-svn/yamcs-erasmus/src/config/


### PR DESCRIPTION
Since event-decoder.yaml is only a non-mandatory sample configuration
file, the name should reflect this.

This is now consistent with event-viewer.yaml.sample