### PR TITLE
CcsdsPacket: improve toString() and add unit test

### DIFF
--- a/yamcs-api/src/test/java/org/yamcs/api/CcsdsPacketTest.java
+++ b/yamcs-api/src/test/java/org/yamcs/api/CcsdsPacketTest.java
@@ -1,0 +1,56 @@
+package org.yamcs.api;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.yamcs.utils.TimeEncoding;
+import org.yamcs.utils.CcsdsPacket;
+
+import java.nio.ByteBuffer;
+
+public class CcsdsPacketTest {
+
+    // Non multiple of 16 bytes
+    byte[] testPacketOf34Bytes = new byte[] {
+            (byte)0x1b,(byte)0x8a,(byte)0xe1,(byte)0x54,(byte)0x00,(byte)0x5b,(byte)0x46,(byte)0x7f,(byte)0xb3,(byte)0x56,(byte)0x72,(byte)0x45,(byte)0x13,(byte)0x00,(byte)0xe2,(byte)0x2b,
+            (byte)0xa1,(byte)0x92,(byte)0x03,(byte)0x00,(byte)0x00,(byte)0x26,(byte)0x00,(byte)0x01,(byte)0x00,(byte)0x90,(byte)0x00,(byte)0x30,(byte)0x07,(byte)0xe1,(byte)0x01,(byte)0x33,
+            (byte)0x00,(byte)0xec
+    };
+
+    // Multiple of 16 bytes
+    byte[] testPacketOf32Bytes = new byte[] {
+            (byte)0x1b,(byte)0x8a,(byte)0xe1,(byte)0x54,(byte)0x00,(byte)0x5b,(byte)0x46,(byte)0x7f,(byte)0xb3,(byte)0x56,(byte)0x72,(byte)0x45,(byte)0x13,(byte)0x00,(byte)0xe2,(byte)0x2b,
+            (byte)0xa1,(byte)0x92,(byte)0x03,(byte)0x00,(byte)0x00,(byte)0x26,(byte)0x00,(byte)0x01,(byte)0x00,(byte)0x90,(byte)0x00,(byte)0x30,(byte)0x07,(byte)0xe1,(byte)0x01,(byte)0x33,
+    };
+
+    @Test
+    public void testToString() {
+        CcsdsPacket ccsdsPacket = new CcsdsPacket(ByteBuffer.wrap(testPacketOf34Bytes));
+        // Initialize TimeEncoding to be able to call CcsdsPacket.toString()
+        TimeEncoding.setUp();
+
+        String packetString = ccsdsPacket.toString();
+        Assert.assertEquals("apid: 906\n" +
+                "packetId: 318825003\n" +
+                "time: 2017-06-29/180T12:21:24.445\n" +
+                "0000: 1b8a e154 005b 467f b356 7245 1300 e22b ...T.[F\u007F.VrE...+\n" +
+                "0010: a192 0300 0026 0001 0090 0030 07e1 0133 .....&.....0...3\n" +
+                "0020: 00ec                                    ..              \n\n", packetString);
+    }
+
+
+    @Test
+    public void testToString16() {
+        CcsdsPacket ccsdsPacket = new CcsdsPacket(ByteBuffer.wrap(testPacketOf32Bytes));
+        // Initialize TimeEncoding to be able to call CcsdsPacket.toString()
+        TimeEncoding.setUp();
+
+        String packetString = ccsdsPacket.toString();
+        Assert.assertEquals("apid: 906\n" +
+                "packetId: 318825003\n" +
+                "time: 2017-06-29/180T12:21:24.445\n" +
+                "0000: 1b8a e154 005b 467f b356 7245 1300 e22b ...T.[F\u007F.VrE...+\n" +
+                "0010: a192 0300 0026 0001 0090 0030 07e1 0133 .....&.....0...3\n\n", packetString);
+    }
+
+
+}


### PR DESCRIPTION
The old toString() of CcsdsPacket did not output the final
ASCII bytes of a CcsdsPacket if the size was not a multiple of 16.

It also did not have any unit tests.

This commit improves the toString() by ensuring all ASCII bytes are
output and adds 2 unit tests to test the 16-byte-multiple and the
non-16-byte-multiple cases.