### PR TITLE
Fix yamcs-monitor pp replays

### DIFF
--- a/yamcs-core/src/main/java/org/yamcs/ui/archivebrowser/ArchivePanel.java
+++ b/yamcs-core/src/main/java/org/yamcs/ui/archivebrowser/ArchivePanel.java
@@ -560,7 +560,7 @@ public class ArchivePanel extends JPanel implements PropertyChangeListener {
     public List<String> getSelectedPackets(String tableName) {
         DataViewer dataViewer = (DataViewer) activeItem;
         if(dataViewer.getDataView().indexBoxes.containsKey(tableName)) {
-            return dataViewer.getDataView().getSelectedPackets("tm");
+            return dataViewer.getDataView().getSelectedPackets(tableName);
         }
         return Collections.emptyList();
     }

--- a/yamcs-core/src/main/java/org/yamcs/ui/yamcsmonitor/ArchiveBrowserSelector.java
+++ b/yamcs-core/src/main/java/org/yamcs/ui/yamcsmonitor/ArchiveBrowserSelector.java
@@ -122,7 +122,9 @@ public class ArchiveBrowserSelector extends ArchiveBrowser implements ActionList
             if ( sel == null ) {
                 showError("Select the range you want to apply. Then try again");
             } else {
-                List<String> packets = archivePanel.getSelectedPackets("tm");
+                // Add all TM and PP packets to the list of parameters to replay
+                ArrayList<String> packets = new ArrayList<String>(archivePanel.getSelectedPackets("tm"));
+                packets.addAll(archivePanel.getSelectedPackets("pp"));
                 ProcessorWidget widget=YamcsMonitor.theApp.getActiveProcessorWidget();
                 if(widget instanceof ArchiveProcWidget) {
                     ((ArchiveProcWidget) widget).apply(getInstance(), sel.getStartInstant(), sel.getStopInstant(), packets.toArray(new String[0]));


### PR DESCRIPTION
The Archive Browser allows selecting TM and PP packets for a replay
but selecting PP's did not work, only TM packets were added.

This fixes B-USOC redmine issue #371