### PR TITLE
Fix disabled "Apply Selection" button for PP's

### DIFF
--- a/yamcs-core/src/main/java/org/yamcs/ui/archivebrowser/ArchivePanel.java
+++ b/yamcs-core/src/main/java/org/yamcs/ui/archivebrowser/ArchivePanel.java
@@ -147,7 +147,7 @@ public class ArchivePanel extends JPanel implements PropertyChangeListener {
         };
         itemsByName.put(tmViewer.getLabelName(), tmViewer);
 
-        DataViewer ppViewer = new DataViewer(archiveBrowser.yconnector, archiveBrowser.indexReceiver, this, false) {
+        DataViewer ppViewer = new DataViewer(archiveBrowser.yconnector, archiveBrowser.indexReceiver, this, replayEnabled) {
             @Override
             public String getLabelName() {
                 return "Processed Parameters";


### PR DESCRIPTION
On the "Processed Parameters" panel of the Archive Browser,
the "Apply Selection" button is initially disabled and gets
enabled when a date range is selected.

But this behavior was broken in commit 2cbce606244 and the
button did not get enabled anymore, unless you went
to the Telemetry panel and selected a date range first.

This commit restores the button's functionality.