### PR TITLE
YaMCS client tools: enable authentication

### DIFF
--- a/yamcs-core/etc/yamcs-ui.yaml.sample
+++ b/yamcs-core/etc/yamcs-ui.yaml.sample
@@ -1,5 +1,5 @@
 #if set to true, the yamcs connect dialog will allow to specify the username/password to be used for connecting to yamcs
-authenticationEnabled: false
+authenticationEnabled: true
 
 #tools that show in the menu of the archive browser
 archiveBrowserTools: []


### PR DESCRIPTION
Enable authentication in the yamcs-ui.yaml.sample
because it is often required.

It does not hurt to have authentication enabled by default
for all users because the YaMCS server will ignore any credentials
it if it's not configured for authentication anyway.