### PR TITLE
Improvements to parameter extraction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ bin/
 *.iml
 
 target/
+yamcs-artemis/lib/
 yamcs-core/lib/
 live
 doc/yamcs-manual.fo

--- a/yamcs-core/src/main/java/org/yamcs/web/rest/ParameterReplayToChunkedCSVEncoder.java
+++ b/yamcs-core/src/main/java/org/yamcs/web/rest/ParameterReplayToChunkedCSVEncoder.java
@@ -22,18 +22,26 @@ import io.netty.buffer.ByteBufOutputStream;
 public class ParameterReplayToChunkedCSVEncoder extends ParameterReplayToChunkedTransferEncoder {
     
     private ParameterFormatter formatter;
+    private boolean addRaw;
+    private boolean addMonitoring;
     
-    public ParameterReplayToChunkedCSVEncoder(RestRequest req, List<NamedObjectId> idList) throws HttpException {
+    public ParameterReplayToChunkedCSVEncoder(RestRequest req, List<NamedObjectId> idList, boolean addRaw, boolean addMonitoring) throws HttpException {
         super(req, MediaType.CSV, idList);
+        this.addRaw = addRaw;
+        this.addMonitoring = addMonitoring;
+
+        resetBuffer();
         formatter.setWriteHeader(true);
     }
     
     @Override
     protected void resetBuffer() {
         super.resetBuffer();
-        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(bufOut));
-        formatter = new ParameterFormatter(bw, idList, '\t');
+        BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(bufOut));
+        formatter = new ParameterFormatter(writer, idList, '\t');
         formatter.setWriteHeader(false);
+        formatter.setPrintRaw(addRaw);
+        formatter.setPrintMonitoring(addMonitoring);
     }
     
     @Override


### PR DESCRIPTION
The changes in this pr fix a few annoyances that became apparent while talking with @tomvanbraeckel 

* parameter-extractor.sh was assuming MDB:OPS Name as the namespace. That should no longer be our default -- anywhere. With these commits it will default to XTCE qualified names (with option to override).

* parameter-extractor.sh does not correctly report server errors. This pr improves it a little bit (by removing an unnecessary stacktrace) but more improvements are needed in future work. For some reason the RestClient from yamcs-api keeps calling receiveData() even when an exception is already generated. Further the caught exception does not actually contain the RestExceptionMessage sent by the server. I suspect it may have to do with the chunked transfer logic.

* Expose options on REST API for adding raw and monitoring information to CSV output.