### PR TITLE
HttpRequestHandler: support old and new websocket path

### DIFF
--- a/yamcs-core/src/main/java/org/yamcs/web/HttpRequestHandler.java
+++ b/yamcs-core/src/main/java/org/yamcs/web/HttpRequestHandler.java
@@ -199,24 +199,29 @@ public class HttpRequestHandler extends ChannelInboundHandlerAdapter {
                 // overview of all instances
                 fileRequestHandler.handleStaticFileRequest(ctx, req, "_site/index.html");
                 return;
-            default:
-                String yamcsInstance = path[1];
-                if (!YamcsServer.hasInstance(yamcsInstance)) {
-                    sendPlainTextError(ctx, req, NOT_FOUND);
+            case WebSocketFrameHandler.WEBSOCKET_PATH:
+                if (path.length == 2) { // An instance should be specified
+                    sendPlainTextError(ctx, req, FORBIDDEN);
                     return;
                 }
-                if (path.length > 2) {
-                    String[] rpath = path[2].split("/", 2);
-                    String handler = rpath[0];
-                    if (WebSocketFrameHandler.WEBSOCKET_PATH.equals(handler)) {
-                        prepareChannelForWebSocketUpgrade(ctx, req, yamcsInstance, authToken);
-                        return;
+                if (YamcsServer.hasInstance(path[2])) {
+                    prepareChannelForWebSocketUpgrade(ctx, req, path[2], authToken);
+                } else {
+                    sendPlainTextError(ctx, req, NOT_FOUND);
+                }
+                return;
+            default:
+                if (path.length >= 3 && WebSocketFrameHandler.WEBSOCKET_PATH.equals(path[2])) {
+                    if (YamcsServer.hasInstance(path[1])) {
+                        log.warn(String.format("Deprecated url request for /%s/%s. Migrate to /%s/%s instead.",
+                                path[1], path[2], path[2], path[1]));
+                        prepareChannelForWebSocketUpgrade(ctx, req, path[1], authToken);
                     } else {
-                        // Everything else is handled by angular's router
-                        // (enables deep linking in html5 mode)
-                        fileRequestHandler.handleStaticFileRequest(ctx, req, "_site/instance.html");
+                        sendPlainTextError(ctx, req, NOT_FOUND);
                     }
                 } else {
+                    // Everything else is handled by angular's router
+                    // (enables deep linking in html5 mode)
                     fileRequestHandler.handleStaticFileRequest(ctx, req, "_site/instance.html");
                 }
             }


### PR DESCRIPTION
The URL used to be http://yamcs:8090/instancename/_websocket
and it is now http://yamcs:8090/_websocket/instancename

Both are supported, but the former is deprecated.

This code was backported from master so that Yamcs Studio
builds from master are compatible with Yamcs 3.4.x