### PR TITLE
Tweak init script to not use 'su - yamcs'

### DIFF
--- a/contrib/sysvinit/yamcs-server
+++ b/contrib/sysvinit/yamcs-server
@@ -50,7 +50,8 @@ case "$1" in
             for i in 4 3 2 1 0; do
                if [ -f $OUTERR.$i ] ; then mv $OUTERR.$i $OUTERR.$((i+1)) ; fi
             done
-            su - $YAMCS_USER sh -c "YAMCS_DAEMON=1; export YAMCS_DAEMON; nohup $YAMCS_BIN >$OUTERR.0  2>&1 & echo \$! >$PID_FILE"
+            #written such that /etc/profile.d scripts do not trigger
+            su -c "YAMCS_DAEMON=1; export YAMCS_DAEMON; cd; nohup $YAMCS_BIN >$OUTERR.0  2>&1 & echo \$! >$PID_FILE" $YAMCS_USER
             pid=`cat $PID_FILE`
             i=0
             #wait up to $WAIT_FOR_START seconds, maybe the database has to be loaded

--- a/yamcs.spec
+++ b/yamcs.spec
@@ -1,6 +1,6 @@
 Name: 		yamcs
 Version: 	$VERSION$+r$REVISION$
-Release: 	10
+Release: 	1
 
 Group:		MCS
 Summary: 	Mission Control System


### PR DESCRIPTION
This printed an error message on a recent centos with KDE because
of a file /etc/profile.d/kde.sh that assumes the home directory
of the yamcs user is writable (it is not).