### PR TITLE
Fix: No component factory found for SelectParameterDialog

### DIFF
--- a/yamcs-web/packages/app/src/app/monitor/MonitorModule.ts
+++ b/yamcs-web/packages/app/src/app/monitor/MonitorModule.ts
@@ -1,5 +1,6 @@
 import { NgModule } from '@angular/core';
 import { SharedModule } from '../shared/SharedModule';
+import { SelectParameterDialog } from '../mdb/parameters/SelectParameterDialog';
 import { AcknowledgeAlarmDialog } from './alarms/AcknowledgeAlarmDialog';
 import { AlarmDetail } from './alarms/AlarmDetail';
 import { CreateDisplayDialog } from './displays/CreateDisplayDialog';
@@ -40,6 +41,7 @@ const dialogComponents = [
   ExportArchiveDataDialog,
   RenameDisplayDialog,
   RenameLayoutDialog,
+  SelectParameterDialog,
   UploadFilesDialog,
 ];
 


### PR DESCRIPTION
Fix for `"No component factory found for SelectParameterDialog"` error when trying to add new monitor display parameter