### PR TITLE
Prevent ByteBuffer compatibility issues between jdk 8 and 9+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -356,6 +356,25 @@
 
   <profiles>
     <profile>
+      <id>java8-compatibility</id>
+      <activation>
+        <jdk>[9,)</jdk>
+      </activation>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-compiler-plugin</artifactId>
+              <configuration>
+                <release>8</release>
+              </configuration>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+      </build>
+    </profile>
+    <profile>
       <id>yamcs-release</id>
       <build>
         <plugins>


### PR DESCRIPTION
The return type of some ByteBuffer methods are changed
since JDK9 causing issues when running code compiled
with JDK9+ versions on JDK8.