### PR TITLE
Fix #361. Add support for Xinclude in XTCE configurations

### DIFF
--- a/yamcs-xtce/src/main/java/org/yamcs/xtce/xml/IncludeAwareEventReader.java
+++ b/yamcs-xtce/src/main/java/org/yamcs/xtce/xml/IncludeAwareEventReader.java
@@ -1,0 +1,245 @@
+package org.yamcs.xtce.xml;
+
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.net.URI;
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+import javax.xml.namespace.QName;
+import javax.xml.stream.XMLEventReader;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.events.Attribute;
+import javax.xml.stream.events.Characters;
+import javax.xml.stream.events.StartElement;
+import javax.xml.stream.events.XMLEvent;
+
+/**
+ * Implements an {@link XMLEventReader} that handles <code>xi:include</code>
+ * elements, in a limited way. Only file relative or absolute file references
+ * in the <code>href</code> attribute are supported, and the <code>xi:fallback</code>
+ * sub-element is not used. Also, only <code>xml</code> parsing of the included
+ * file is supported.
+ */
+public class IncludeAwareEventReader implements XMLEventReader {
+	
+	private static final String XINCLUDE_NAMESPACE = "http://www.w3.org/2001/XInclude";
+	private static final QName XINCLUDE_TAG = new QName(XINCLUDE_NAMESPACE, "include");
+	private static final QName XINCLUDE_HREF_ATTR = new QName("href");
+	private static final QName XINCLUDE_PARSE_ATTR = new QName("parse");
+
+	private XMLInputFactory factory;
+	private URI baseURI;
+	private Deque<XMLEventReader> readers = new ArrayDeque<>();
+	
+	/**
+	 * Creates a new instance.
+	 * 
+	 * @param factory the input factory to use for creating the {@link XMLEventReader}
+	 *     for the main file and any included files
+	 * @param path the path to the main XML file
+	 * @throws FileNotFoundException if any file cannot be found
+	 * @throws XMLStreamException if there is an XML parsing error in the main file
+	 *     or any included file
+	 */
+	public IncludeAwareEventReader(XMLInputFactory factory, String path) throws FileNotFoundException, XMLStreamException {
+		this.factory = factory;
+		File f = new File(path);
+		baseURI = f.toURI();
+		readers.add(createFileEventReader(f));
+	}
+	
+	/**
+	 * Creates an {@link XMLEventReader} for a given file.
+	 * 
+	 * @param f the file to read
+	 * @return an {@link XMLEventReader} for the file
+	 * @throws FileNotFoundException if the file does not exist
+	 * @throws XMLStreamException if there is a problem creating the event reader
+	 */
+	private XMLEventReader createFileEventReader(File f) throws FileNotFoundException, XMLStreamException {
+		return factory.createXMLEventReader(new BufferedInputStream(new FileInputStream(f)));
+	}
+
+	/**
+	 * Starts a new include level for an XML file.
+	 * 
+	 * @param reader the XML event reader for the file
+	 */
+	private void pushReader(XMLEventReader reader) {
+		readers.addFirst(reader);
+	}
+	
+	/**
+	 * Leaves an include level to return to the parent file.
+	 */
+	private void popReader() {
+		readers.removeFirst();
+	}
+
+	/**
+	 * Gets the {@link XMLEventReader} for the current include level.
+	 * 
+	 * @return the current {@link XMLEventReader}
+	 * @throw IllegalStateException if an attempt is made to leave the top reading level
+	 */
+	private XMLEventReader getReader() {
+		if (readers.isEmpty()) {
+			throw new IllegalStateException("Should not happen: all readers are popped");
+		}
+		return readers.getFirst();
+	}
+
+	/**
+	 * Tests whether we are currently reading events from an included file.
+	 * 
+	 * @return true, if we are reading events from an included file instead of the
+	 *     top-level file
+	 */
+	private boolean isProcessingInclude() {
+		return readers.size() > 1;
+	}
+	
+	@Override
+	public Object next() {
+		try {
+			return nextEvent();
+		} catch (XMLStreamException e) {
+			throw new IllegalStateException("Unexpected exception while iterating over events", e);
+		}
+	}
+
+	@Override
+	public XMLEvent nextEvent() throws XMLStreamException {
+		peek();
+		return getReader().nextEvent();
+	}
+
+	@Override
+	public boolean hasNext() {
+		try {
+			peek();
+		} catch (XMLStreamException e) {
+			// Ignore
+		}
+		return getReader().hasNext();
+	}
+
+	@Override
+	public XMLEvent peek() throws XMLStreamException {
+		for (;;) {
+			XMLEvent event = getReader().peek();
+			
+			if (isIncludeStartElement(event)) {
+				// Start a new include.
+				pushReader(createIncludeReader(event.asStartElement()));
+			} else if (!isProcessingInclude()) {
+				// Otherwise, if we're not in an include, just return the
+				// event from the base reader.
+				return event;
+			} else if (event == null) {
+				// End-of-file in an include. Move to enclosing reader.
+				popReader();
+			} else if (event.isStartDocument() || event.isEndDocument()) {
+				// Skip start/end document events in an included file.
+				getReader().nextEvent();
+			} else {
+				// Otherwise a good event from an included file.
+				return event;
+			}
+		}
+	}
+	
+	/**
+	 * Tests whether an event is an <code>xi:include</code> start element.
+	 * 
+	 * @param event the {@link XMLEvent}
+	 * @return true, if the event represents the start of an <code>xi:include</code>
+	 */
+	private boolean isIncludeStartElement(XMLEvent event) {
+		if (event==null || !event.isStartElement()) {
+			return false;
+		}
+		
+		StartElement element = event.asStartElement();
+		return element.getName().equals(XINCLUDE_TAG);
+	}
+	
+	/**
+	 * Gets a new {@link XMLEventReader} for an included file.
+	 * 
+	 * @param element the starting element for the <code>xi:include</code>
+	 * @return a new {@link XMLEventReader} for the included file
+	 * @throws XMLStreamException if there is an error accessing the included file or
+	 *    creating the <code>XMLEventReader</code>
+	 */
+	private XMLEventReader createIncludeReader(StartElement element) throws XMLStreamException {
+		// Read the xi:include start element event.
+		getReader().nextEvent();
+		
+		// Read to the closing xi:include tag.
+		getReader().getElementText();
+		
+		Attribute parseAttr = element.getAttributeByName(XINCLUDE_PARSE_ATTR);
+		if (parseAttr!=null && !parseAttr.getValue().equals("xml")) {
+			throw new XMLStreamException("Only XML parsing of <xi:include> is supported");
+		}
+		
+		String uri = element.getAttributeByName(XINCLUDE_HREF_ATTR).getValue();
+		File includeFile = new File(baseURI.resolve(uri));
+		try {
+			return createFileEventReader(includeFile);
+		} catch (FileNotFoundException e) {
+			throw new XMLStreamException("Cannot read file: " + includeFile.getAbsolutePath(), e);
+		}
+	}
+
+	@Override
+	public String getElementText() throws XMLStreamException {
+		return getReader().getElementText();
+	}
+
+	@Override
+	public XMLEvent nextTag() throws XMLStreamException {
+		for (;;) {
+			XMLEvent event = peek();
+			if (event==null || event.isStartElement() || event.isEndElement()) {
+				if (event != null) {
+					// Move into the element, if not end-of-file.
+					getReader().nextEvent();
+				}
+				return event;
+			}
+			
+			if (!event.isCharacters()) {
+				throw new XMLStreamException("Unexpected event in nextTag(): " + event);
+			}
+			
+			Characters characters = event.asCharacters();
+			if (!characters.isWhiteSpace()) {
+				throw new XMLStreamException("Nonwhitespace character encountered in nextTag(): " + characters);
+			}
+			
+			// Otherwise we found whitespace characters. Remove the event.
+			getReader().nextEvent();
+		}
+	}
+
+	@Override
+	public Object getProperty(String name) throws IllegalArgumentException {
+		// Always return the properties of the base reader.
+		return readers.getLast().getProperty(name);
+	}
+
+	@Override
+	public void close() throws XMLStreamException {
+		while (!readers.isEmpty()) {
+			getReader().close();
+			popReader();
+		}
+	}
+
+}

--- a/yamcs-xtce/src/main/java/org/yamcs/xtce/xml/XtceStaxReader.java
+++ b/yamcs-xtce/src/main/java/org/yamcs/xtce/xml/XtceStaxReader.java
@@ -3,11 +3,8 @@
  */
 package org.yamcs.xtce.xml;
 
-import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.io.InputStream;
 import java.nio.ByteOrder;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -3586,9 +3583,7 @@ public class XtceStaxReader {
      * @throws XMLStreamException
      */
     private XMLEventReader initEventReader(String filename) throws FileNotFoundException, XMLStreamException {
-        InputStream in = new FileInputStream(new File(filename));
-        XMLInputFactory factory = XMLInputFactory.newInstance();
-        return factory.createXMLEventReader(in);
+        return new IncludeAwareEventReader(XMLInputFactory.newInstance(), filename);
     }
 
     /**

--- a/yamcs-xtce/src/test/java/org/yamcs/xtce/xml/IncludeAwareEventReaderTest.java
+++ b/yamcs-xtce/src/test/java/org/yamcs/xtce/xml/IncludeAwareEventReaderTest.java
@@ -1,0 +1,121 @@
+package org.yamcs.xtce.xml;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.FileNotFoundException;
+
+import javax.xml.namespace.QName;
+import javax.xml.stream.XMLEventReader;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.events.XMLEvent;
+
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Implements unit tests for {@link IncludeAwareEventReader}.
+ */
+public class IncludeAwareEventReaderTest {
+	
+	private static final String XTCE_NAMESPACE = "http://www.omg.org/spec/XTCE/20180204";
+	private static final QName SPACE_SYSTEM_TAG = new QName(XTCE_NAMESPACE, "SpaceSystem");
+
+    private XMLInputFactory factory;
+    
+	@Before
+	public void setup() {
+		factory = XMLInputFactory.newInstance();
+	}
+	
+	/**
+	 * Tests the event sequence when reading a file with no includes.
+	 * 
+	 * @throws FileNotFoundException if the included file is not found
+	 * @throws XMLStreamException if there is an XML parsing error
+	 */
+	@Test
+	public void testNoXInclude() throws FileNotFoundException, XMLStreamException {
+		XMLEventReader reader = new IncludeAwareEventReader(factory, "src/test/resources/xinclude/simple-document.xml");
+		assertTrue(reader.nextEvent().isStartDocument());
+		assertTrue(reader.nextEvent().isStartElement());
+		assertTrue(reader.nextEvent().isEndElement());
+		assertTrue(reader.nextEvent().isEndDocument());
+		assertFalse(reader.hasNext());
+		reader.close();
+	}
+	
+	/**
+	 * Tests the sequence of events when reading an XML file containing an
+	 * include.
+	 * 
+	 * @throws FileNotFoundException if the included file is not found
+	 * @throws XMLStreamException if there is an XML parsing error
+	 */
+	@Test
+	public void testWithXInclude() throws FileNotFoundException, XMLStreamException {
+		checkWithXInclude("src/test/resources/xinclude/top-level.xml");
+		checkWithXInclude("src/test/resources/xinclude/top-level-with-parse.xml");
+	}
+	
+	private void checkWithXInclude(String path) throws FileNotFoundException, XMLStreamException {
+		XMLEventReader reader = new IncludeAwareEventReader(factory, path);
+		assertTrue(reader.nextEvent().isStartDocument());
+		XMLEvent topTag = reader.nextEvent();
+		assertTrue(topTag.isStartElement());
+		assertTrue(topTag.asStartElement().getName().equals(SPACE_SYSTEM_TAG));
+		
+		XMLEvent includedTag = reader.nextTag();
+		assertTrue(includedTag.isStartElement());
+		assertTrue(includedTag.asStartElement().getName().equals(SPACE_SYSTEM_TAG));
+		assertTrue(reader.nextTag().isEndElement());
+		
+		assertTrue(reader.nextTag().isEndElement());
+		assertTrue(reader.nextEvent().isEndDocument());
+		assertFalse(reader.hasNext());
+		reader.close();
+	}
+	
+	/**
+	 * Tests that including a file that doesn't exist throws an exception.
+	 * 
+	 * @throws FileNotFoundException if the included file is not found
+	 * @throws XMLStreamException if there is an XML parsing error
+	 */
+	@Test
+	public void testIncludedFileNotFound() throws FileNotFoundException, XMLStreamException {
+		XMLEventReader reader = new IncludeAwareEventReader(factory, "src/test/resources/xinclude/file-not-found.xml");
+		assertTrue(reader.nextEvent().isStartDocument());
+		XMLEvent topTag = reader.nextEvent();
+		assertTrue(topTag.isStartElement());
+		assertTrue(topTag.asStartElement().getName().equals(SPACE_SYSTEM_TAG));
+		
+		// Try to read the included file.
+		try {
+			reader.nextTag();
+			fail("Should have gotten an exception reading into the xi:include");
+		} catch (XMLStreamException e) {
+			// If we get here, test passes.
+		}
+	}
+	
+	@Test
+	public void testNonXMLInclude() throws FileNotFoundException, XMLStreamException {
+		XMLEventReader reader = new IncludeAwareEventReader(factory, "src/test/resources/xinclude/non-xml-include.xml");
+		assertTrue(reader.nextEvent().isStartDocument());
+		XMLEvent topTag = reader.nextEvent();
+		assertTrue(topTag.isStartElement());
+		assertTrue(topTag.asStartElement().getName().equals(SPACE_SYSTEM_TAG));
+		
+		// Try to read the included file.
+		try {
+			reader.nextTag();
+			fail("Should have gotten an exception reading into the xi:include");
+		} catch (XMLStreamException e) {
+			// If we get here, test passes.
+		}
+	}
+	
+}

--- a/yamcs-xtce/src/test/java/org/yamcs/xtce/xml/XtceStaxReaderTest.java
+++ b/yamcs-xtce/src/test/java/org/yamcs/xtce/xml/XtceStaxReaderTest.java
@@ -1,0 +1,66 @@
+package org.yamcs.xtce.xml;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import java.util.Iterator;
+
+import javax.xml.stream.XMLStreamException;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.yamcs.xtce.SpaceSystem;
+
+/**
+ * Implements unit tests for {@link XtceStaxReader}.
+ */
+public class XtceStaxReaderTest {
+
+	private XtceStaxReader reader;
+	
+	@Before
+	public void setup() {
+		reader = new XtceStaxReader();
+	}
+	
+	/**
+	 * Tests that a space system created by reading a single XML file
+	 * is the same as that created by reading an XML file broken into
+	 * three parts using xi:include.
+	 * 
+	 * @throws XMLStreamException if there is an XML parsing error
+	 * @throws IOException if there is a problem reading an XML file
+	 */
+	@Test
+	public void testIncludedAgainstCombined() throws XMLStreamException, IOException {
+		SpaceSystem combined = reader.readXmlDocument("src/test/resources/xinclude/combined-space-system.xml");
+		SpaceSystem included = reader.readXmlDocument("src/test/resources/xinclude/top-space-system.xml");
+		
+		compareSpaceSystems(combined, included);
+	}
+	
+	/**
+	 * Compares two SpaceSystem objects. Verifies only that the lengths of
+	 * the telemetry types, parameters, and containers are the same, that 
+	 * the lengths of the metacommands are the same, and verifies each
+	 * subsystem recursively.
+	 * 
+	 * @param expected the space system with the expected structure
+	 * @param actual the space system to compare against
+	 */
+	private void compareSpaceSystems(SpaceSystem expected, SpaceSystem actual) {
+		assertEquals(expected.getName(), actual.getName());
+		assertEquals(expected.getParameterTypes().size(), actual.getParameterTypes().size());
+		assertEquals(expected.getParameters().size(), actual.getParameters().size());
+		assertEquals(expected.getSequenceContainers().size(), actual.getSequenceContainers().size());
+		assertEquals(expected.getMetaCommands().size(), actual.getMetaCommands().size());
+		assertEquals(expected.getSubSystems().size(), actual.getSubSystems().size());
+		
+		Iterator<SpaceSystem> expectedIter = expected.getSubSystems().iterator();
+		Iterator<SpaceSystem> actualIter = actual.getSubSystems().iterator();
+		while (expectedIter.hasNext()) {
+			compareSpaceSystems(expectedIter.next(), actualIter.next());
+		}
+	}
+	
+}

--- a/yamcs-xtce/src/test/resources/xinclude/combined-space-system.xml
+++ b/yamcs-xtce/src/test/resources/xinclude/combined-space-system.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xtce:SpaceSystem xmlns:xtce="http://www.omg.org/spec/XTCE/20180204" name="TOP_LEVEL"
+    xmlns:xi="http://www.w3.org/2001/XInclude">
+
+    <xtce:TelemetryMetaData>
+        <xtce:ParameterTypeSet>
+            <xtce:IntegerParameterType name="param0Type" sizeInBits="8" signed="false">
+                <xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+            </xtce:IntegerParameterType>
+        </xtce:ParameterTypeSet>
+        <xtce:ParameterSet>
+            <xtce:Parameter parameterTypeRef="param0Type" name="param0" />
+        </xtce:ParameterSet>
+        <xtce:ContainerSet>
+            <xtce:SequenceContainer name="container0">
+                <xtce:EntryList>
+                    <xtce:ParameterRefEntry parameterRef="param0" />
+                </xtce:EntryList>
+            </xtce:SequenceContainer>
+        </xtce:ContainerSet>
+    </xtce:TelemetryMetaData>
+    
+    <xtce:CommandMetaData>
+        <xtce:MetaCommandSet>
+            <xtce:MetaCommand name="command0" />
+        </xtce:MetaCommandSet>
+    </xtce:CommandMetaData>
+    
+    <xtce:SpaceSystem name="SUB_ONE">
+        <xtce:TelemetryMetaData>
+            <xtce:ParameterTypeSet>
+                <xtce:IntegerParameterType name="param1Type" sizeInBits="8" signed="false">
+                    <xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+                </xtce:IntegerParameterType>
+            </xtce:ParameterTypeSet>
+            <xtce:ParameterSet>
+                <xtce:Parameter parameterTypeRef="param1Type" name="param2" />
+            </xtce:ParameterSet>
+            <xtce:ContainerSet>
+                <xtce:SequenceContainer name="container1">
+                    <xtce:EntryList>
+                        <xtce:ParameterRefEntry parameterRef="param1" />
+                    </xtce:EntryList>
+                </xtce:SequenceContainer>
+            </xtce:ContainerSet>
+        </xtce:TelemetryMetaData>
+        
+        <xtce:CommandMetaData>
+            <xtce:MetaCommandSet>
+                <xtce:MetaCommand name="command1" />
+            </xtce:MetaCommandSet>
+        </xtce:CommandMetaData>
+    </xtce:SpaceSystem>
+    
+    <xtce:SpaceSystem name="SUB_TWO">
+        <xtce:TelemetryMetaData>
+            <xtce:ParameterTypeSet>
+                <xtce:IntegerParameterType name="param2Type" sizeInBits="8" signed="false">
+                    <xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+                </xtce:IntegerParameterType>
+            </xtce:ParameterTypeSet>
+            <xtce:ParameterSet>
+                <xtce:Parameter parameterTypeRef="param2Type" name="param2" />
+            </xtce:ParameterSet>
+            <xtce:ContainerSet>
+                <xtce:SequenceContainer name="container2">
+                    <xtce:EntryList>
+                        <xtce:ParameterRefEntry parameterRef="param2" />
+                    </xtce:EntryList>
+                </xtce:SequenceContainer>
+            </xtce:ContainerSet>
+        </xtce:TelemetryMetaData>
+        
+        <xtce:CommandMetaData>
+            <xtce:MetaCommandSet>
+                <xtce:MetaCommand name="command2" />
+            </xtce:MetaCommandSet>
+        </xtce:CommandMetaData>
+    </xtce:SpaceSystem>
+    
+    <xtce:SpaceSystem name="SUB_THREE">
+        <xtce:TelemetryMetaData>
+            <xtce:ParameterTypeSet>
+                <xtce:IntegerParameterType name="param3Type" sizeInBits="8" signed="false">
+                    <xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+                </xtce:IntegerParameterType>
+            </xtce:ParameterTypeSet>
+            <xtce:ParameterSet>
+                <xtce:Parameter parameterTypeRef="param3Type" name="param3" />
+            </xtce:ParameterSet>
+            <xtce:ContainerSet>
+                <xtce:SequenceContainer name="container3">
+                    <xtce:EntryList>
+                        <xtce:ParameterRefEntry parameterRef="param3" />
+                    </xtce:EntryList>
+                </xtce:SequenceContainer>
+            </xtce:ContainerSet>
+        </xtce:TelemetryMetaData>
+        
+        <xtce:CommandMetaData>
+            <xtce:MetaCommandSet>
+                <xtce:MetaCommand name="command3" />
+            </xtce:MetaCommandSet>
+        </xtce:CommandMetaData>
+    </xtce:SpaceSystem>
+    
+</xtce:SpaceSystem>

--- a/yamcs-xtce/src/test/resources/xinclude/file-not-found.xml
+++ b/yamcs-xtce/src/test/resources/xinclude/file-not-found.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<xtce:SpaceSystem xmlns:xtce="http://www.omg.org/spec/XTCE/20180204" name="SYSTEM"
+  xmlns:xi="http://www.w3.org/2001/XInclude">
+   <xi:include href="no-such-file.xml" />
+</xtce:SpaceSystem>

--- a/yamcs-xtce/src/test/resources/xinclude/included.xml
+++ b/yamcs-xtce/src/test/resources/xinclude/included.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<xtce:SpaceSystem xmlns:xtce="http://www.omg.org/spec/XTCE/20180204" name="SUB_SYSTEM">
+</xtce:SpaceSystem>

--- a/yamcs-xtce/src/test/resources/xinclude/non-xml-include.xml
+++ b/yamcs-xtce/src/test/resources/xinclude/non-xml-include.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<xtce:SpaceSystem xmlns:xtce="http://www.omg.org/spec/XTCE/20180204" name="SYSTEM"
+  xmlns:xi="http://www.w3.org/2001/XInclude">
+   <xi:include href="included.xml" parse="text" />
+</xtce:SpaceSystem>

--- a/yamcs-xtce/src/test/resources/xinclude/simple-document.xml
+++ b/yamcs-xtce/src/test/resources/xinclude/simple-document.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<sample />

--- a/yamcs-xtce/src/test/resources/xinclude/sub-space-system-one.xml
+++ b/yamcs-xtce/src/test/resources/xinclude/sub-space-system-one.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xtce:SpaceSystem xmlns:xtce="http://www.omg.org/spec/XTCE/20180204" name="SUB_ONE"
+    xmlns:xi="http://www.w3.org/2001/XInclude">
+    
+    <xtce:TelemetryMetaData>
+        <xtce:ParameterTypeSet>
+            <xtce:IntegerParameterType name="param1Type" sizeInBits="8" signed="false">
+                <xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+            </xtce:IntegerParameterType>
+        </xtce:ParameterTypeSet>
+        <xtce:ParameterSet>
+            <xtce:Parameter parameterTypeRef="param1Type" name="param2" />
+        </xtce:ParameterSet>
+        <xtce:ContainerSet>
+            <xtce:SequenceContainer name="container1">
+                <xtce:EntryList>
+                    <xtce:ParameterRefEntry parameterRef="param1" />
+                </xtce:EntryList>
+            </xtce:SequenceContainer>
+        </xtce:ContainerSet>
+    </xtce:TelemetryMetaData>
+    
+    <xtce:CommandMetaData>
+        <xtce:MetaCommandSet>
+            <xtce:MetaCommand name="command1" />
+        </xtce:MetaCommandSet>
+    </xtce:CommandMetaData>
+
+</xtce:SpaceSystem>

--- a/yamcs-xtce/src/test/resources/xinclude/sub-space-system-three.xml
+++ b/yamcs-xtce/src/test/resources/xinclude/sub-space-system-three.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xtce:SpaceSystem xmlns:xtce="http://www.omg.org/spec/XTCE/20180204" name="SUB_THREE"
+    xmlns:xi="http://www.w3.org/2001/XInclude">
+    
+    <xtce:TelemetryMetaData>
+        <xtce:ParameterTypeSet>
+            <xtce:IntegerParameterType name="param3Type" sizeInBits="8" signed="false">
+                <xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+            </xtce:IntegerParameterType>
+        </xtce:ParameterTypeSet>
+        <xtce:ParameterSet>
+            <xtce:Parameter parameterTypeRef="param3Type" name="param3" />
+        </xtce:ParameterSet>
+        <xtce:ContainerSet>
+            <xtce:SequenceContainer name="container3">
+                <xtce:EntryList>
+                    <xtce:ParameterRefEntry parameterRef="param3" />
+                </xtce:EntryList>
+            </xtce:SequenceContainer>
+        </xtce:ContainerSet>
+    </xtce:TelemetryMetaData>
+    
+    <xtce:CommandMetaData>
+        <xtce:MetaCommandSet>
+            <xtce:MetaCommand name="command3" />
+        </xtce:MetaCommandSet>
+    </xtce:CommandMetaData>
+
+</xtce:SpaceSystem>

--- a/yamcs-xtce/src/test/resources/xinclude/top-level-with-parse.xml
+++ b/yamcs-xtce/src/test/resources/xinclude/top-level-with-parse.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<xtce:SpaceSystem xmlns:xtce="http://www.omg.org/spec/XTCE/20180204" name="SYSTEM"
+  xmlns:xi="http://www.w3.org/2001/XInclude">
+   <xi:include href="included.xml" parse="xml" />
+</xtce:SpaceSystem>

--- a/yamcs-xtce/src/test/resources/xinclude/top-level.xml
+++ b/yamcs-xtce/src/test/resources/xinclude/top-level.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<xtce:SpaceSystem xmlns:xtce="http://www.omg.org/spec/XTCE/20180204" name="SYSTEM"
+  xmlns:xi="http://www.w3.org/2001/XInclude">
+   <xi:include href="included.xml" />
+</xtce:SpaceSystem>

--- a/yamcs-xtce/src/test/resources/xinclude/top-space-system.xml
+++ b/yamcs-xtce/src/test/resources/xinclude/top-space-system.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xtce:SpaceSystem xmlns:xtce="http://www.omg.org/spec/XTCE/20180204" name="TOP_LEVEL"
+    xmlns:xi="http://www.w3.org/2001/XInclude">
+
+    <xtce:TelemetryMetaData>
+        <xtce:ParameterTypeSet>
+            <xtce:IntegerParameterType name="param0Type" sizeInBits="8" signed="false">
+                <xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+            </xtce:IntegerParameterType>
+        </xtce:ParameterTypeSet>
+        <xtce:ParameterSet>
+            <xtce:Parameter parameterTypeRef="param0Type" name="param0" />
+        </xtce:ParameterSet>
+        <xtce:ContainerSet>
+            <xtce:SequenceContainer name="container0">
+                <xtce:EntryList>
+                    <xtce:ParameterRefEntry parameterRef="param0" />
+                </xtce:EntryList>
+            </xtce:SequenceContainer>
+        </xtce:ContainerSet>
+    </xtce:TelemetryMetaData>
+    
+    <xtce:CommandMetaData>
+        <xtce:MetaCommandSet>
+            <xtce:MetaCommand name="command0" />
+        </xtce:MetaCommandSet>
+    </xtce:CommandMetaData>
+
+    <xi:include href="sub-space-system-one.xml" />
+
+    <xtce:SpaceSystem name="SUB_TWO">
+        <xtce:TelemetryMetaData>
+            <xtce:ParameterTypeSet>
+                <xtce:IntegerParameterType name="param2Type" sizeInBits="8" signed="false">
+                    <xtce:IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
+                </xtce:IntegerParameterType>
+            </xtce:ParameterTypeSet>
+            <xtce:ParameterSet>
+                <xtce:Parameter parameterTypeRef="param2Type" name="param2" />
+            </xtce:ParameterSet>
+            <xtce:ContainerSet>
+                <xtce:SequenceContainer name="container2">
+                    <xtce:EntryList>
+                        <xtce:ParameterRefEntry parameterRef="param2" />
+                    </xtce:EntryList>
+                </xtce:SequenceContainer>
+            </xtce:ContainerSet>
+        </xtce:TelemetryMetaData>
+        
+        <xtce:CommandMetaData>
+            <xtce:MetaCommandSet>
+                <xtce:MetaCommand name="command2" />
+            </xtce:MetaCommandSet>
+        </xtce:CommandMetaData>
+    </xtce:SpaceSystem>
+    
+    <xi:include href="sub-space-system-three.xml" />
+    
+</xtce:SpaceSystem>


### PR DESCRIPTION
Add a filtering XMLEventReader that supports XInclude tags. Add unit
tests and test files.