### PR TITLE
Use cmdPostProcessor.getBinaryLength() when fitting commands into frame

### DIFF
--- a/yamcs-core/src/main/java/org/yamcs/tctm/ccsds/TcPacketHandler.java
+++ b/yamcs-core/src/main/java/org/yamcs/tctm/ccsds/TcPacketHandler.java
@@ -67,7 +67,7 @@ public class TcPacketHandler extends AbstractTcDataLink implements VcUplinkHandl
         List<PreparedCommand> l = new ArrayList<>();
         PreparedCommand pc;
         while ((pc = commandQueue.peek()) != null) {
-            int pcLength = pc.getBinary().length;
+            int pcLength = cmdPostProcessor.getBinaryLength(pc);
             if (framingLength + dataLength + pcLength < vmp.maxFrameLength) {
                 pc = commandQueue.poll();
                 if (pc == null) {


### PR DESCRIPTION
This change bring the TcPacketHandler class in sync with Cop1TcPacketHandler class.

Without this change, the code throw an exception on line [102](https://github.com/yamcs/yamcs/blob/7c1634e6dab32b5553c6c5026700c2797e25eb96/yamcs-core/src/main/java/org/yamcs/tctm/ccsds/TcPacketHandler.java#L102) of TcPacketHandler.java when the cmdPostProcessor return an array larger than the binary in the PreparedCommand.  In our case, a CCSDS Encapsulated Packet header is prepended to the binary by our cmdPostProcessor, causing the mismatch.  Using the getBinaryLength() fixes the issue.
