### PR TITLE
Time Correlation Service Fixes

### DIFF
--- a/docs/server-manual/services/instance/time-correlation.rst
+++ b/docs/server-manual/services/instance/time-correlation.rst
@@ -82,6 +82,7 @@ This service is defined in ``etc/yamcs.(instance).yaml``. Example:
         name: tco0
         args:            
             onboardDelay: 0.0
+            useTofEstimator: false
             defaultTof: 0.0
             accuracy: 0.1
             validity: 0.2
@@ -94,6 +95,9 @@ Configuration Options
     
 onboardDelay  (double)
     the on-board delay in seconds used to compute the on-board transmission time from the earth reception time. The default value is 0 seconds.
+
+useTofEstimator (boolean)
+    Flag to enable or disable time of flight estimator service. The default value is false. Enable time of flight estimator service when it is required to dynamically compute the time of flight.
 
 defaultTof (double)
     The default time of flight in seconds. This value is used if the tof estimator does not return a value because no interval has been configured.

--- a/yamcs-core/src/main/java/org/yamcs/time/TimeCorrelationService.java
+++ b/yamcs-core/src/main/java/org/yamcs/time/TimeCorrelationService.java
@@ -184,7 +184,8 @@ public class TimeCorrelationService extends AbstractYamcsService implements Syst
         spec.addOption("validity", OptionType.FLOAT).withDefault(0.2);
         spec.addOption("saveCoefficients", OptionType.BOOLEAN).withDefault(true);
         spec.addOption("saveTofPolynomials", OptionType.BOOLEAN).withDefault(true);
-
+        spec.addOption("defaultTof", OptionType.FLOAT).withDefault(0.0);
+        
         return spec;
     }
 
@@ -195,6 +196,7 @@ public class TimeCorrelationService extends AbstractYamcsService implements Syst
         sampleQueue = new ArrayDeque<>(numSamples);
         accuracy = config.getDouble("accuracy", 0.1);
         validity = config.getDouble("validity", 0.2);
+        defaultTof = config.getDouble("deafaultTof", 0.0);        
 
         boolean saveCoefficients = config.getBoolean("saveCoefficients", true);
         boolean saveTofPolynomials = config.getBoolean("saveTofPolynomials", true);
@@ -271,7 +273,7 @@ public class TimeCorrelationService extends AbstractYamcsService implements Syst
      *             if the obt or ert are smaller than the ones in the previous sample
      */
     public synchronized void addSample(long obt, Instant ert) {
-        double delay = tofEstimator.getTof(ert) + onboardDelay;
+        double delay = getTof(ert) + onboardDelay;
         Instant obi = ert.plus(-delay);
 
         if (!sampleQueue.isEmpty()) {
@@ -368,7 +370,7 @@ public class TimeCorrelationService extends AbstractYamcsService implements Syst
 
         TcoCoefficients c = curCoefficients;
         if (c == null) {
-            double delay = tofEstimator.getTof(ert) + onboardDelay;
+            double delay = getTof(ert) + onboardDelay;
             Instant genTime = ert.plus(-delay);
             pkt.setGenerationTime(genTime.getMillis());
             pkt.setLocalGenTimeFlag();
@@ -411,7 +413,7 @@ public class TimeCorrelationService extends AbstractYamcsService implements Syst
         if (ert == null || ert == Instant.INVALID_INSTANT) {
             throw new IllegalArgumentException("no ert available");
         }
-        double delay = tofEstimator.getTof(ert) + onboardDelay;
+        double delay = getTof(ert) + onboardDelay;
         Instant expectedGenTime = ert.plus(-delay);
 
         double deviation = expectedGenTime.deltaFrom(Instant.get(pkt.getGenerationTime()));

--- a/yamcs-core/src/main/java/org/yamcs/time/TimeCorrelationService.java
+++ b/yamcs-core/src/main/java/org/yamcs/time/TimeCorrelationService.java
@@ -185,7 +185,8 @@ public class TimeCorrelationService extends AbstractYamcsService implements Syst
         spec.addOption("saveCoefficients", OptionType.BOOLEAN).withDefault(true);
         spec.addOption("saveTofPolynomials", OptionType.BOOLEAN).withDefault(true);
         spec.addOption("defaultTof", OptionType.FLOAT).withDefault(0.0);
-        
+        spec.addOption("useTofEstimator", OptionType.BOOLEAN).withDefault(false);
+
         return spec;
     }
 
@@ -200,9 +201,15 @@ public class TimeCorrelationService extends AbstractYamcsService implements Syst
 
         boolean saveCoefficients = config.getBoolean("saveCoefficients", true);
         boolean saveTofPolynomials = config.getBoolean("saveTofPolynomials", true);
+        boolean useTofEstimator = config.getBoolean("useTofEstimator", false);
 
-        tofEstimator = new TimeOfFlightEstimator(yamcsInstance, serviceName, saveTofPolynomials);
-
+        if (useTofEstimator) {
+            tofEstimator = new TimeOfFlightEstimator(yamcsInstance, serviceName, saveTofPolynomials);
+        }
+        else {
+            tofEstimator = null;
+        }
+        
         this.timeService = YamcsServer.getTimeService(yamcsInstance);
         if (saveCoefficients) {
             tableName = TABLE_NAME + serviceName;


### PR DESCRIPTION
Time Correlation Service has been modified to read the default time of flight set in the configuration.
Delay computation now reverts to default tof in case the ERT Start, Stop are not updated via the API instead of NaN.
An additional configuration option to enable or disable time of flight estimation is added.