### PR TITLE
Fixed bug when trying to find filesystem bucket.

### DIFF
--- a/yamcs-core/src/main/java/org/yamcs/cfdp/CfdpIncomingTransfer.java
+++ b/yamcs-core/src/main/java/org/yamcs/cfdp/CfdpIncomingTransfer.java
@@ -541,13 +541,19 @@ public class CfdpIncomingTransfer extends OngoingCfdpTransfer {
     }
 
     private String getFileName(String name) throws IOException {
+    	/**
+    	 *@todo This assumes that filesystem separator is "/". Shouldn't this be configurable?
+    	 */
         name = name.replace("/", "_");
-        if (incomingBucket.getObject(name) == null) {
+        if (incomingBucket.findObject(name) == null) {
             return name;
         }
+        /**
+         *@note Any chance we can make this "10000" configurable?
+         */
         for (int i = 1; i < 10000; i++) {
             String namei = name + "(" + i + ")";
-            if (incomingBucket.getObject(namei) == null) {
+            if (incomingBucket.findObject(namei) == null) {
                 return namei;
             }
         }

--- a/yamcs-core/src/main/java/org/yamcs/yarch/FileSystemBucket.java
+++ b/yamcs-core/src/main/java/org/yamcs/yarch/FileSystemBucket.java
@@ -116,7 +116,11 @@ public class FileSystemBucket implements Bucket {
     @Override
     public byte[] getObject(String objectName) throws IOException {
         Path path = root.resolve(objectName);
-        return Files.readAllBytes(path);
+        if(Files.exists(path)) {
+        	return Files.readAllBytes(path);
+        } else {
+        	return null;
+        }
     }
 
     @Override


### PR DESCRIPTION
<!--
Thank you for opening a Pull Request! Before submitting anything
non-trivial (more than a few lines), there are a few things you can
do to make sure it goes smoothly:

* Please start a discussion, before writing your code! That way we
  can discuss the change, evaluate designs, and agree on the general
  idea.

* You will need to sign a Contributor License Agreement (CLA):
  https://yamcs.org/static/Yamcs_Contributor_Agreement_v2.0.pdf

  You remain owner of your contribution, but in addition you give
  "Space Applications Services" the legal permission to use and
  distribute your contribution. This ensures that we can continue
  providing alternative licensing as a commercial feature.

Thanks again!
-->

Hello everyone,

hope you are all doing well.

My team and I have started to use the `cfdp` capabilities. When we set everything up we noticed that when doing a download on the downlink, YAMCS did not write the file to the filesystem. Even when configuring the buckets correctly. This is the issue I am addressing with this PR. I figured this change does not need a github discussion as it is a very trivial fix. If it does let me know.


The issue was that as you can see the implementation of getObject function in `FileSystemBucket` _assumes_ that the file exists and starts reading bytes from it. This would throw an IOException and it would not write the file to the filesystem at all. Instead I'm using  `findObject` which is specifically written for this purpose and does not start reading from the filesystem. I hope this makes sense.


I have also added two comments suggesting potential issues with some hardcoded values. These are more to start the discussion regarding these potential issues that the comments point to. If you would like me to remove these comments please let me know. But just wanted to make you guys aware.

I hope this PR is simple and concise, I tried my best to keep it that way.

Thanks in advance
Lorenzo





