### PR TITLE
File transfer chunk size

### DIFF
--- a/yamcs-web/src/main/webapp/src/app/filetransfer/DownloadFileDialog.html
+++ b/yamcs-web/src/main/webapp/src/app/filetransfer/DownloadFileDialog.html
@@ -60,7 +60,7 @@
     </ng-container>
     <label>
       Local Entity
-      <select formControlName="destination">
+      <select formControlName="source">
         <option *ngFor="let entity of service.localEntities"
                 [value]="entity.name">{{ entity.name }} [id={{ entity.id}}]</option>
       </select>
@@ -68,7 +68,7 @@
     <br>
     <label>
       Remote Entity
-      <select formControlName="source">
+      <select formControlName="destination">
         <option *ngFor="let entity of service.remoteEntities"
                 [value]="entity.name">{{ entity.name }} [id={{ entity.id}}]</option>
       </select>

--- a/yamcs-web/src/main/webapp/src/app/filetransfer/DownloadFileDialog.ts
+++ b/yamcs-web/src/main/webapp/src/app/filetransfer/DownloadFileDialog.ts
@@ -36,8 +36,8 @@ export class DownloadFileDialog {
     @Inject(MAT_DIALOG_DATA) readonly data: any,
   ) {
     this.service = data.service;
-    const firstSource = this.service.remoteEntities.length ? this.service.remoteEntities[0].name : '';
-    const firstDestination = this.service.localEntities.length ? this.service.localEntities[0].name : '';
+    const firstSource = this.service.localEntities.length ? this.service.localEntities[0].name : '';
+    const firstDestination = this.service.remoteEntities.length ? this.service.remoteEntities[0].name : '';
 
     this.storageClient = yamcs.createStorageClient();
     this.storageClient.getBuckets('_global').then(buckets => {


### PR DESCRIPTION
Previously the 'source' and 'destination' form controls were flipped for downloads, as in "source = remote entity" and "dest = local entity" to denote direction of data. But now it is "source = local entity" and "dest = remote entity" because this is where the request goes.

This is needed so we can pin the chunk size on the local entity, both for uploads and downloads.