### PR TITLE
Support variable length binary types

### DIFF
--- a/yamcs-core/src/main/java/org/yamcs/xtceproc/DataEncodingDecoder.java
+++ b/yamcs-core/src/main/java/org/yamcs/xtceproc/DataEncodingDecoder.java
@@ -22,7 +22,7 @@ import org.yamcs.xtce.StringDataEncoding;
  * Decodes TM data according to the specification of the DataEncoding
  * This is a generic catch all decoder, relies on specific custom decoders implementing
  * the DataDecoder interface when necessary.
- *
+ * 
  * @see org.yamcs.xtceproc.DataDecoder
  *
  * @author nm
@@ -44,7 +44,7 @@ public class DataEncodingDecoder {
 
     /**
      * Extracts the raw uncalibrated parameter value from the buffer.
-     *
+     * 
      * @return the extracted value or null if something went wrong - in this case the parameter will be marked with
      *         aquisitionStatus = INVALID
      */
@@ -168,13 +168,13 @@ public class DataEncodingDecoder {
             if(sde.getSizeInBits()==-1) {
                 while (buffer.getByte() != sde.getTerminationChar()) {
                     sizeInBytes++;
-                }
+                }    
                 extraBytes = 1;
             } else {
                 int maxSize = sde.getSizeInBits() >> 3;
                 while (sizeInBytes<maxSize && buffer.getByte() != sde.getTerminationChar()) {
                     sizeInBytes++;
-                }
+                } 
                 extraBytes = maxSize - sizeInBytes;
             }
             buffer.setPosition(position);
@@ -211,7 +211,7 @@ public class DataEncodingDecoder {
             return ValueUtility.getDoubleValue(Double.longBitsToDouble(buffer.getBits(64)));
         }
     }
-
+    
     private Value extractRawMILSTD_1750A(FloatDataEncoding de) {
         buffer.setByteOrder(de.getByteOrder());
 
@@ -278,7 +278,7 @@ public class DataEncodingDecoder {
 
     /**
      * return the nominal Value.Type of a raw value corresponding to the given XTCE data encoding definition
-     *
+     * 
      * @param encoding
      * @return
      */

--- a/yamcs-core/src/main/java/org/yamcs/xtceproc/DataEncodingEncoder.java
+++ b/yamcs-core/src/main/java/org/yamcs/xtceproc/DataEncodingEncoder.java
@@ -20,7 +20,7 @@ import org.yamcs.xtce.StringDataEncoding;
 
 /**
  * Encodes TC data according to the DataEncoding definition
- *
+ * 
  * @author nm
  *
  */

--- a/yamcs-core/src/main/java/org/yamcs/xtceproc/DataEncodingEncoder.java
+++ b/yamcs-core/src/main/java/org/yamcs/xtceproc/DataEncodingEncoder.java
@@ -36,21 +36,6 @@ public class DataEncodingEncoder {
      * Encode the raw value of the argument into the packet.
      */
     public void encodeRaw(DataEncoding de, Value rawValue) {
-        encodeRaw(de, rawValue, null);
-    }
-
-    /**
-     * Encode the raw value of the argument into the packet, using the
-     * specified processing context to look up referenced arguments, if
-     * necessary.
-     *
-     * @param de the data encoding
-     * @param rawValue the raw value to encode
-     * @param pcontext the telecommand processing context
-     */
-    public void encodeRaw(DataEncoding de, Value rawValue,
-            TcProcessingContext pcontext) {
-
         pcontext.bitbuf.setByteOrder(de.getByteOrder());
 
         if (de.getToBinaryTransformAlgorithm() != null) {

--- a/yamcs-core/src/main/java/org/yamcs/xtceproc/DataEncodingEncoder.java
+++ b/yamcs-core/src/main/java/org/yamcs/xtceproc/DataEncodingEncoder.java
@@ -4,11 +4,13 @@ import java.nio.ByteOrder;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.yamcs.commanding.ArgumentValue;
 import org.yamcs.parameter.Value;
 import org.yamcs.protobuf.Yamcs.Value.Type;
 import org.yamcs.utils.BitBuffer;
 import org.yamcs.utils.MilStd1750A;
 import org.yamcs.utils.StringConverter;
+import org.yamcs.utils.ValueUtility;
 import org.yamcs.xtce.BinaryDataEncoding;
 import org.yamcs.xtce.DataEncoding;
 import org.yamcs.xtce.FloatDataEncoding;
@@ -18,7 +20,7 @@ import org.yamcs.xtce.StringDataEncoding;
 
 /**
  * Encodes TC data according to the DataEncoding definition
- * 
+ *
  * @author nm
  *
  */
@@ -34,6 +36,21 @@ public class DataEncodingEncoder {
      * Encode the raw value of the argument into the packet.
      */
     public void encodeRaw(DataEncoding de, Value rawValue) {
+        encodeRaw(de, rawValue, null);
+    }
+
+    /**
+     * Encode the raw value of the argument into the packet, using the
+     * specified processing context to look up referenced arguments, if
+     * necessary.
+     *
+     * @param de the data encoding
+     * @param rawValue the raw value to encode
+     * @param pcontext the telecommand processing context
+     */
+    public void encodeRaw(DataEncoding de, Value rawValue,
+            TcProcessingContext pcontext) {
+
         pcontext.bitbuf.setByteOrder(de.getByteOrder());
 
         if (de.getToBinaryTransformAlgorithm() != null) {
@@ -47,7 +64,7 @@ public class DataEncodingEncoder {
             } else if (de instanceof StringDataEncoding) {
                 encodeRawString((StringDataEncoding) de, rawValue);
             } else if (de instanceof BinaryDataEncoding) {
-                encodeRawBinary((BinaryDataEncoding) de, rawValue);
+                encodeRawBinary((BinaryDataEncoding) de, rawValue, pcontext);
             } else {
                 log.error("DataEncoding {} not implemented", de);
                 throw new IllegalArgumentException("DataEncoding " + de + " not implemented");
@@ -243,7 +260,9 @@ public class DataEncodingEncoder {
         }
     }
 
-    private void encodeRawBinary(BinaryDataEncoding bde, Value rawValue) {
+    private void encodeRawBinary(BinaryDataEncoding bde, Value rawValue,
+            TcProcessingContext pcontext) {
+
         byte[] v;
         if (rawValue.getType() == Type.BINARY) {
             v = rawValue.getBinaryValue();
@@ -268,6 +287,30 @@ public class DataEncodingEncoder {
             bitbuf.putBits(v.length, bde.getSizeInBitsOfSizeTag()); // bde.getSizeInBitsOfSizeTag() can be 0 but bitbuf
                                                                     // won't mind
             bitbuf.put(v);
+            break;
+        case DYNAMIC:
+            String sizeName = bde.getSizeReference().getName();
+            ArgumentValue sizeValue = pcontext.getArgumentValue(sizeName);
+            if (sizeValue == null) {
+                throw new IllegalStateException(
+                        "No argument supplied for binary variable size: "
+                                + sizeName);
+            }
+            ValueUtility.processAsLong(sizeValue.getEngValue(), sizeInBits -> {
+                if (sizeInBits % 8 != 0) {
+                    throw new IllegalArgumentException(
+                            "Binary variable size argument is not a multiple of 8: "
+                                    + sizeInBits);
+                }
+                int dynSizeInBytes = (int) (sizeInBits / 8);
+                int dataSizeInBytes = Math.min(dynSizeInBytes, v.length);
+                bitbuf.put(v, 0, dataSizeInBytes);
+                if (dynSizeInBytes > v.length) {
+                    // Fill with nulls to reach the required size.
+                    byte[] nuls = new byte[dynSizeInBytes - dataSizeInBytes];
+                    bitbuf.put(nuls);
+                }
+            });
             break;
         default:
             throw new IllegalStateException("Unsupported size type " + bde.getType());

--- a/yamcs-core/src/main/java/org/yamcs/xtceproc/MetaCommandContainerProcessor.java
+++ b/yamcs-core/src/main/java/org/yamcs/xtceproc/MetaCommandContainerProcessor.java
@@ -115,7 +115,7 @@ public class MetaCommandContainerProcessor {
                 throw new CommandEncodingException("No encoding available for type '" + atype.getName()
                         + "' used for argument '" + argName + "'");
             }
-            pcontext.deEncoder.encodeRaw(encoding, rawValue, pcontext);
+            pcontext.deEncoder.encodeRaw(encoding, rawValue);
         } else if (atype instanceof AggregateArgumentType) {
             AggregateArgumentType aggtype = (AggregateArgumentType) atype;
             AggregateValue aggRawValue = (AggregateValue)rawValue;

--- a/yamcs-core/src/main/java/org/yamcs/xtceproc/MetaCommandContainerProcessor.java
+++ b/yamcs-core/src/main/java/org/yamcs/xtceproc/MetaCommandContainerProcessor.java
@@ -7,7 +7,21 @@ import org.yamcs.commanding.ArgumentValue;
 import org.yamcs.parameter.AggregateValue;
 import org.yamcs.parameter.Value;
 import org.yamcs.utils.BitBuffer;
-import org.yamcs.xtce.*;
+import org.yamcs.xtce.AggregateArgumentType;
+import org.yamcs.xtce.Argument;
+import org.yamcs.xtce.ArgumentEntry;
+import org.yamcs.xtce.ArgumentType;
+import org.yamcs.xtce.BaseDataType;
+import org.yamcs.xtce.CommandContainer;
+import org.yamcs.xtce.Container;
+import org.yamcs.xtce.DataEncoding;
+import org.yamcs.xtce.FixedValueEntry;
+import org.yamcs.xtce.Member;
+import org.yamcs.xtce.MetaCommand;
+import org.yamcs.xtce.Parameter;
+import org.yamcs.xtce.ParameterEntry;
+import org.yamcs.xtce.ParameterType;
+import org.yamcs.xtce.SequenceEntry;
 
 public class MetaCommandContainerProcessor {
     Logger log = LoggerFactory.getLogger(this.getClass().getName());
@@ -115,7 +129,7 @@ public class MetaCommandContainerProcessor {
                 throw new CommandEncodingException("No encoding available for type '" + atype.getName()
                         + "' used for argument '" + argName + "'");
             }
-            pcontext.deEncoder.encodeRaw(encoding, rawValue);
+            pcontext.deEncoder.encodeRaw(encoding, rawValue, pcontext);
         } else if (atype instanceof AggregateArgumentType) {
             AggregateArgumentType aggtype = (AggregateArgumentType) atype;
             AggregateValue aggRawValue = (AggregateValue)rawValue;

--- a/yamcs-core/src/main/java/org/yamcs/xtceproc/MetaCommandContainerProcessor.java
+++ b/yamcs-core/src/main/java/org/yamcs/xtceproc/MetaCommandContainerProcessor.java
@@ -7,21 +7,7 @@ import org.yamcs.commanding.ArgumentValue;
 import org.yamcs.parameter.AggregateValue;
 import org.yamcs.parameter.Value;
 import org.yamcs.utils.BitBuffer;
-import org.yamcs.xtce.AggregateArgumentType;
-import org.yamcs.xtce.Argument;
-import org.yamcs.xtce.ArgumentEntry;
-import org.yamcs.xtce.ArgumentType;
-import org.yamcs.xtce.BaseDataType;
-import org.yamcs.xtce.CommandContainer;
-import org.yamcs.xtce.Container;
-import org.yamcs.xtce.DataEncoding;
-import org.yamcs.xtce.FixedValueEntry;
-import org.yamcs.xtce.Member;
-import org.yamcs.xtce.MetaCommand;
-import org.yamcs.xtce.Parameter;
-import org.yamcs.xtce.ParameterEntry;
-import org.yamcs.xtce.ParameterType;
-import org.yamcs.xtce.SequenceEntry;
+import org.yamcs.xtce.*;
 
 public class MetaCommandContainerProcessor {
     Logger log = LoggerFactory.getLogger(this.getClass().getName());

--- a/yamcs-core/src/main/java/org/yamcs/xtceproc/SequenceEntryProcessor.java
+++ b/yamcs-core/src/main/java/org/yamcs/xtceproc/SequenceEntryProcessor.java
@@ -1,7 +1,6 @@
 package org.yamcs.xtceproc;
 
 import java.util.List;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.yamcs.parameter.AggregateValue;
@@ -73,10 +72,11 @@ public class SequenceEntryProcessor {
             }
 
             cpc1.sequenceContainerProcessor.extract(subsribedContainer);
-            if (ce.getRefContainer().getSizeInBits() < 0)
+            if (ce.getRefContainer().getSizeInBits() < 0) {
                 buf.setPosition(buf.getPosition() + buf1.getPosition());
-            else
+            } else {
                 buf.setPosition(buf.getPosition() + ce.getRefContainer().getSizeInBits());
+            }
         }
     }
 
@@ -236,6 +236,6 @@ public class SequenceEntryProcessor {
                     "Encountered parameter entry with a parameter type '" + ptype.getName()
                             + " without an encoding");
         }
-        return pcontext.dataEncodingProcessor.extractRaw(encoding);
+        return pcontext.dataEncodingProcessor.extractRaw(encoding, pcontext);
     }
 }

--- a/yamcs-core/src/main/java/org/yamcs/xtceproc/SequenceEntryProcessor.java
+++ b/yamcs-core/src/main/java/org/yamcs/xtceproc/SequenceEntryProcessor.java
@@ -1,6 +1,7 @@
 package org.yamcs.xtceproc;
 
 import java.util.List;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.yamcs.parameter.AggregateValue;
@@ -72,11 +73,10 @@ public class SequenceEntryProcessor {
             }
 
             cpc1.sequenceContainerProcessor.extract(subsribedContainer);
-            if (ce.getRefContainer().getSizeInBits() < 0) {
+            if (ce.getRefContainer().getSizeInBits() < 0)
                 buf.setPosition(buf.getPosition() + buf1.getPosition());
-            } else {
+            else
                 buf.setPosition(buf.getPosition() + ce.getRefContainer().getSizeInBits());
-            }
         }
     }
 

--- a/yamcs-core/src/main/java/org/yamcs/xtceproc/TcProcessingContext.java
+++ b/yamcs-core/src/main/java/org/yamcs/xtceproc/TcProcessingContext.java
@@ -11,7 +11,7 @@ import org.yamcs.xtce.Parameter;
 
 /**
  * Keeps track of where we are when filling in the bits and bytes of a command
- * 
+ *
  * @author nm
  *
  */
@@ -21,7 +21,7 @@ public class TcProcessingContext {
 
     // arguments and their values
     final private Map<Argument, ArgumentValue> argValues;
-    
+
     //context parameters and their values
     final private Map<Parameter, Value> paramValues;
 
@@ -45,8 +45,26 @@ public class TcProcessingContext {
         return argValues.get(arg);
     }
 
+    /**
+     * Look up an argument by name only, for cases in which we do not have the
+     * full argument definition, such as arguments used for defining the length
+     * of other variable-length arguments.
+     *
+     * @param argName the name of the argument
+     * @return the argument value, if found, or null
+     */
+    public ArgumentValue getArgumentValue(String argName) {
+        for (Map.Entry<Argument, ArgumentValue> entry : argValues.entrySet()) {
+            if (argName.equals(entry.getKey().getName())) {
+                return entry.getValue();
+            }
+        }
+
+        return null;
+    }
+
     public Value getParameterValue(Parameter param) {
-        Value v = paramValues.get(param); 
+        Value v = paramValues.get(param);
         if(v == null) {
             ParameterValue pv = pdata.getLastValueCache().getValue(param);
             if(pv!=null) {

--- a/yamcs-core/src/main/java/org/yamcs/xtceproc/TcProcessingContext.java
+++ b/yamcs-core/src/main/java/org/yamcs/xtceproc/TcProcessingContext.java
@@ -11,7 +11,7 @@ import org.yamcs.xtce.Parameter;
 
 /**
  * Keeps track of where we are when filling in the bits and bytes of a command
- *
+ * 
  * @author nm
  *
  */
@@ -21,7 +21,7 @@ public class TcProcessingContext {
 
     // arguments and their values
     final private Map<Argument, ArgumentValue> argValues;
-
+    
     //context parameters and their values
     final private Map<Parameter, Value> paramValues;
 
@@ -64,7 +64,7 @@ public class TcProcessingContext {
     }
 
     public Value getParameterValue(Parameter param) {
-        Value v = paramValues.get(param);
+        Value v = paramValues.get(param); 
         if(v == null) {
             ParameterValue pv = pdata.getLastValueCache().getValue(param);
             if(pv!=null) {

--- a/yamcs-core/src/test/java/org/yamcs/xtce/VariableBinaryXtceTest.java
+++ b/yamcs-core/src/test/java/org/yamcs/xtce/VariableBinaryXtceTest.java
@@ -1,0 +1,70 @@
+package org.yamcs.xtce;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import javax.xml.stream.XMLStreamException;
+import org.junit.Before;
+import org.junit.Test;
+import org.yamcs.YConfiguration;
+import org.yamcs.utils.TimeEncoding;
+import org.yamcs.xtce.xml.XtceLoadException;
+import org.yamcs.xtceproc.XtceDbFactory;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests that an XTCE document with a variable-length binary data types can be
+ * parsed successfully.
+ */
+public class VariableBinaryXtceTest {
+
+    private static final String SIZE_QN = "/VariableBinaryTest/size";
+    private static final String DATA_QN = "/VariableBinaryTest/data";
+
+    private static final String COMMAND_QN = "/VariableBinaryTest/Command";
+
+    private XtceDb db;
+
+    @Before
+    public void setup() throws URISyntaxException, XtceLoadException,
+            XMLStreamException, IOException {
+
+        YConfiguration.setupTest(null);
+        db = XtceDbFactory.createInstanceByConfig("VariableBinaryTest");
+
+        TimeEncoding.setUp();
+    }
+
+    @Test
+    public void testReadXtce() throws URISyntaxException, XtceLoadException,
+            XMLStreamException, IOException {
+
+        Parameter dataParameter = db.getParameter(DATA_QN);
+        ParameterType parameterType = dataParameter.getParameterType();
+        DataEncoding de = parameterType.getEncoding();
+        assertTrue(de instanceof BinaryDataEncoding);
+        BinaryDataEncoding bde = (BinaryDataEncoding) de;
+        assertTrue(bde.isVariableSize());
+
+        Parameter sizeParameter = db.getParameter(SIZE_QN);
+        assertEquals(sizeParameter.getQualifiedName(),
+                bde.getSizeReference().getName());
+
+        Argument dataArgument = db.getMetaCommand(COMMAND_QN)
+                .getArgument("data");
+        ArgumentType argumentType = dataArgument.getArgumentType();
+        assertTrue(argumentType instanceof BinaryArgumentType);
+        BinaryArgumentType binaryType = (BinaryArgumentType) argumentType;
+        de = binaryType.getEncoding();
+        assertTrue(de instanceof BinaryDataEncoding);
+        bde = (BinaryDataEncoding) de;
+        assertTrue(bde.isVariableSize());
+
+        Argument sizeArgument = db.getMetaCommand(COMMAND_QN)
+                .getArgument("size");
+        assertEquals(sizeArgument.getName(), bde.getSizeReference().getName());
+
+    }
+
+}

--- a/yamcs-core/src/test/java/org/yamcs/xtceproc/VariableBinaryCommandEncodingTest.java
+++ b/yamcs-core/src/test/java/org/yamcs/xtceproc/VariableBinaryCommandEncodingTest.java
@@ -1,0 +1,77 @@
+package org.yamcs.xtceproc;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.LinkedList;
+import java.util.List;
+import javax.xml.stream.XMLStreamException;
+import org.junit.Before;
+import org.junit.Test;
+import org.yamcs.ErrorInCommand;
+import org.yamcs.ProcessorConfig;
+import org.yamcs.YConfiguration;
+import org.yamcs.xtce.ArgumentAssignment;
+import org.yamcs.xtce.MetaCommand;
+import org.yamcs.xtce.XtceDb;
+import org.yamcs.xtce.xml.XtceLoadException;
+
+import static org.junit.Assert.assertArrayEquals;
+
+/**
+ * Tests that a command containing a variable-length binary argument can be
+ * encoded correctly.
+ */
+public class VariableBinaryCommandEncodingTest {
+
+    private static final String SIZE_QN = "/VariableBinaryTest/size";
+    private static final String DATA_QN = "/VariableBinaryTest/data";
+    private static final String VALUE_QN = "/VariableBinaryTest/value";
+
+    private XtceDb db;
+    private MetaCommandProcessor metaCommandProcessor;
+
+    @Before
+    public void setup() throws URISyntaxException, XtceLoadException,
+            XMLStreamException, IOException {
+
+        YConfiguration.setupTest(null);
+        db = XtceDbFactory
+                .createInstanceByConfig("VariableBinaryTest");
+        metaCommandProcessor = new MetaCommandProcessor(
+                new ProcessorData("test", "test", db, new ProcessorConfig()));
+    }
+
+    @Test
+    public void testCommandEncoding() throws ErrorInCommand, IOException {
+        MetaCommand mc = db.getMetaCommand("/VariableBinaryTest/Command");
+        List<ArgumentAssignment> arguments = new LinkedList<>();
+
+        byte[] data = new byte[] { 1, 2, 3, 4, 5 };
+        StringBuilder builder = new StringBuilder();
+        for (byte b : data) {
+            builder.append(String.format("%02X", b));
+        }
+        arguments.add(new ArgumentAssignment("size",
+                Integer.toString(data.length * 8)));
+        arguments.add(new ArgumentAssignment("data", builder.toString()));
+        arguments.add(new ArgumentAssignment("value", "3.14"));
+        byte[] b = metaCommandProcessor.buildCommand(mc, arguments)
+                .getCmdPacket();
+        byte[] expected = createPacket(data, 3.14F);
+
+        assertArrayEquals(expected, b);
+    }
+
+    private byte[] createPacket(byte[] data, float value) throws IOException {
+        ByteArrayOutputStream arrayStream = new ByteArrayOutputStream();
+        DataOutputStream out = new DataOutputStream(arrayStream);
+
+        out.writeShort(data.length * 8);
+        out.write(data);
+        out.writeInt(Float.floatToIntBits(value));
+
+        return arrayStream.toByteArray();
+    }
+}

--- a/yamcs-core/src/test/java/org/yamcs/xtceproc/VariableBinaryDecodingTest.java
+++ b/yamcs-core/src/test/java/org/yamcs/xtceproc/VariableBinaryDecodingTest.java
@@ -1,0 +1,79 @@
+package org.yamcs.xtceproc;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import javax.xml.stream.XMLStreamException;
+import org.junit.Before;
+import org.junit.Test;
+import org.yamcs.YConfiguration;
+import org.yamcs.parameter.ParameterValueList;
+import org.yamcs.utils.TimeEncoding;
+import org.yamcs.xtce.XtceDb;
+import org.yamcs.xtce.xml.XtceLoadException;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests that a packet containing a binary data type with variable size can be
+ * unpacked correctly.
+ */
+public class VariableBinaryDecodingTest {
+
+    private static final String SIZE_QN = "/VariableBinaryTest/size";
+    private static final String DATA_QN = "/VariableBinaryTest/data";
+    private static final String VALUE_QN = "/VariableBinaryTest/value";
+
+    private XtceDb db;
+
+    @Before
+    public void setup() throws URISyntaxException, XtceLoadException,
+            XMLStreamException, IOException {
+
+        YConfiguration.setupTest(null);
+        db = XtceDbFactory
+                .createInstanceByConfig("VariableBinaryTest");
+
+        TimeEncoding.setUp();
+    }
+
+    @Test
+    public void testProcessPacket() throws IOException {
+        XtceTmExtractor extractor = new XtceTmExtractor(db);
+        extractor.provideAll();
+
+        byte[] data = new byte[] { 1, 2, 3, 4, 5 };
+        byte[] b = createPacket(data, 3.14F);
+        long now = TimeEncoding.getWallclockTime();
+        ContainerProcessingResult result = extractor.processPacket(b, now,
+                now);
+
+        ParameterValueList pvl = result.getParameterResult();
+        assertEquals(1, pvl.count(db.getParameter(SIZE_QN)));
+        assertEquals(1, pvl.count(db.getParameter(DATA_QN)));
+        assertEquals(1, pvl.count(db.getParameter(VALUE_QN)));
+        pvl.forEach(pv -> {
+            if (pv.getParameterQualifiedName().equals(SIZE_QN)) {
+                assertEquals(data.length * 8,
+                        pv.getEngValue().getSint32Value());
+            } else if (pv.getParameterQualifiedName().equals(DATA_QN)) {
+                assertArrayEquals(data, pv.getEngValue().getBinaryValue());
+            } else if (pv.getParameterQualifiedName().equals(VALUE_QN)) {
+                assertEquals(3.14F, pv.getEngValue().getFloatValue(), 1E-6F);
+            }
+        });
+    }
+
+    private byte[] createPacket(byte[] data, float value) throws IOException {
+        ByteArrayOutputStream arrayStream = new ByteArrayOutputStream();
+        DataOutputStream out = new DataOutputStream(arrayStream);
+
+        out.writeShort(data.length * 8);
+        out.write(data);
+        out.writeInt(Float.floatToIntBits(value));
+
+        return arrayStream.toByteArray();
+    }
+}

--- a/yamcs-core/src/test/resources/mdb.yaml
+++ b/yamcs-core/src/test/resources/mdb.yaml
@@ -5,7 +5,7 @@ refmdb:
       args: 
            file: "mdb/refmdb.xls"
            enableAliasReferences: false
-      
+
 
 refmdb-v6:
     # Configuration of the active loaders
@@ -14,28 +14,28 @@ refmdb-v6:
       args: 
            file: "mdb/refmdb-v6.xls"
            enableAliasReferences: false
-      
+
 refxtce:
     - type: xtce
       args:
           file: "src/test/resources/xtce/ref-xtce.xml"
-      
+
 ccsds-green-book:
     - type: xtce
       args:
           file: "src/test/resources/xtce/ccsds-green-book.xml"
 
-      
+
 BogusSAT:
     - type: xtce
       args:
-          file: "src/test/resources/xtce/BogusSAT-1.xml"          
+          file: "src/test/resources/xtce/BogusSAT-1.xml"
 
 BogusSAT2:
     - type: xtce
       args:
           file: "src/test/resources/xtce/BogusSAT-2.xml"
-          
+
 BogusSAT2-noautopart:
     - type: xtce
       args:
@@ -46,14 +46,19 @@ ranges-test:
     - type: xtce
       args:
           file: "../yamcs-xtce/src/test/resources/ranges-test.xml"
-          
+
 empty-match-criteria:
     - type: xtce
       args:
           file: "src/test/resources/xtce/empty-match-criteria.xml"
-          
-          
+
+
 xtce-fileset:
     - type: xtce
       args:
           fileset: ["src/test/resources/xtce/a*.xml", "src/test/resources/xtce/b.xml"]
+
+VariableBinaryTest:
+    - type: xtce
+      args:
+          file: "src/test/resources/xtce/VariableBinary.xml"

--- a/yamcs-core/src/test/resources/mdb.yaml
+++ b/yamcs-core/src/test/resources/mdb.yaml
@@ -5,7 +5,7 @@ refmdb:
       args: 
            file: "mdb/refmdb.xls"
            enableAliasReferences: false
-
+      
 
 refmdb-v6:
     # Configuration of the active loaders
@@ -14,28 +14,28 @@ refmdb-v6:
       args: 
            file: "mdb/refmdb-v6.xls"
            enableAliasReferences: false
-
+      
 refxtce:
     - type: xtce
       args:
           file: "src/test/resources/xtce/ref-xtce.xml"
-
+      
 ccsds-green-book:
     - type: xtce
       args:
           file: "src/test/resources/xtce/ccsds-green-book.xml"
 
-
+      
 BogusSAT:
     - type: xtce
       args:
-          file: "src/test/resources/xtce/BogusSAT-1.xml"
+          file: "src/test/resources/xtce/BogusSAT-1.xml"          
 
 BogusSAT2:
     - type: xtce
       args:
           file: "src/test/resources/xtce/BogusSAT-2.xml"
-
+          
 BogusSAT2-noautopart:
     - type: xtce
       args:
@@ -46,13 +46,13 @@ ranges-test:
     - type: xtce
       args:
           file: "../yamcs-xtce/src/test/resources/ranges-test.xml"
-
+          
 empty-match-criteria:
     - type: xtce
       args:
           file: "src/test/resources/xtce/empty-match-criteria.xml"
-
-
+          
+          
 xtce-fileset:
     - type: xtce
       args:

--- a/yamcs-core/src/test/resources/xtce/VariableBinary.xml
+++ b/yamcs-core/src/test/resources/xtce/VariableBinary.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SpaceSystem xmlns="http://www.omg.org/spec/XTCE/20180204"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:xi="http://www.w3.org/2001/XInclude"
+  name="VariableBinaryTest"
+  shortDescription="Test of binary parameter and argument with variable size"
+  xsi:schemaLocation="http://www.omg.org/spec/XTCE/20180204 https://www.omg.org/spec/XTCE/20180204/SpaceSystem.xsd">
+
+  <TelemetryMetaData>
+    <ParameterTypeSet>
+      <IntegerParameterType name="SizeType" sizeInBits="16">
+        <IntegerDataEncoding sizeInBits="16" byteOrder="mostSignificantByteFirst"
+          encoding="unsigned" />
+      </IntegerParameterType>
+      <FloatParameterType name="FloatType" sizeInBits="32">
+        <FloatDataEncoding sizeInBits="32" byteOrder="mostSignificantByteFirst"
+          encoding="IEEE754_1985"/>
+      </FloatParameterType>
+      <BinaryParameterType name="BinaryType">
+        <BinaryDataEncoding>
+          <SizeInBits>
+            <DynamicValue>
+              <ParameterInstanceRef parameterRef="size"/>
+            </DynamicValue>
+          </SizeInBits>
+        </BinaryDataEncoding>
+      </BinaryParameterType>
+    </ParameterTypeSet>
+    <ParameterSet>
+      <Parameter parameterTypeRef="SizeType" name="size"/>
+      <Parameter parameterTypeRef="BinaryType" name="data"/>
+      <Parameter parameterTypeRef="FloatType" name="value"/>
+    </ParameterSet>
+    <ContainerSet>
+      <SequenceContainer name="Packet">
+        <EntryList>
+          <ParameterRefEntry parameterRef="size"/>
+          <ParameterRefEntry parameterRef="data"/>
+          <ParameterRefEntry parameterRef="value"/>
+        </EntryList>
+      </SequenceContainer>
+    </ContainerSet>
+  </TelemetryMetaData>
+  
+  <CommandMetaData>
+    <ArgumentTypeSet>
+      <IntegerArgumentType name="SizeType" sizeInBits="16" signed="false">
+        <IntegerDataEncoding sizeInBits="16" byteOrder="mostSignificantByteFirst" encoding="unsigned"/>
+      </IntegerArgumentType>
+      <BinaryArgumentType name="BinaryType">
+        <BinaryDataEncoding>
+          <SizeInBits>
+            <DynamicValue>
+              <ArgumentInstanceRef argumentRef="size"/>
+            </DynamicValue>
+          </SizeInBits>
+        </BinaryDataEncoding>
+      </BinaryArgumentType>
+      <FloatArgumentType name="FloatType" sizeInBits="32">
+        <FloatDataEncoding sizeInBits="32" encoding="IEEE754_1985"/>
+      </FloatArgumentType>
+    </ArgumentTypeSet>
+    <MetaCommandSet>
+      <MetaCommand name="Command">
+        <ArgumentList>
+          <Argument argumentTypeRef="SizeType" name="size"/>
+          <Argument argumentTypeRef="BinaryType" name="data"/>
+          <Argument argumentTypeRef="FloatType" name="value"/>
+        </ArgumentList>
+        <CommandContainer name="CommandContainer">
+          <EntryList>
+            <ArgumentRefEntry argumentRef="size"/>
+            <ArgumentRefEntry argumentRef="data"/>
+            <ArgumentRefEntry argumentRef="value"/>
+          </EntryList>
+        </CommandContainer>
+      </MetaCommand>
+    </MetaCommandSet>
+  </CommandMetaData>
+
+</SpaceSystem>

--- a/yamcs-xtce/src/main/java/org/yamcs/xtce/BinaryDataEncoding.java
+++ b/yamcs-xtce/src/main/java/org/yamcs/xtce/BinaryDataEncoding.java
@@ -1,7 +1,7 @@
 package org.yamcs.xtce;
 
 /**
- *
+ * 
  * Although XTCE suggests that this class could be used to encode/decode integer/float/string data, In Yamcs this is
  * used just for
  * encoding binary data (i.e. binary to binary). See {@link DataEncoding} for how to use the other classes to
@@ -26,7 +26,7 @@ public class BinaryDataEncoding extends DataEncoding {
 
     /**
      * copy constructor
-     *
+     * 
      * @param bde
      */
     public BinaryDataEncoding(BinaryDataEncoding bde) {

--- a/yamcs-xtce/src/main/java/org/yamcs/xtce/BinaryDataEncoding.java
+++ b/yamcs-xtce/src/main/java/org/yamcs/xtce/BinaryDataEncoding.java
@@ -1,7 +1,7 @@
 package org.yamcs.xtce;
 
 /**
- * 
+ *
  * Although XTCE suggests that this class could be used to encode/decode integer/float/string data, In Yamcs this is
  * used just for
  * encoding binary data (i.e. binary to binary). See {@link DataEncoding} for how to use the other classes to
@@ -17,7 +17,7 @@ public class BinaryDataEncoding extends DataEncoding {
     private static final long serialVersionUID = 2L;
 
     public enum Type {
-        FIXED_SIZE, LEADING_SIZE, CUSTOM
+        FIXED_SIZE, LEADING_SIZE, CUSTOM, DYNAMIC
     }
 
     int sizeInBitsOfSizeTag = 16; // this is used when type is LEADING_SIZE to encod the length of the value before the
@@ -26,7 +26,7 @@ public class BinaryDataEncoding extends DataEncoding {
 
     /**
      * copy constructor
-     * 
+     *
      * @param bde
      */
     public BinaryDataEncoding(BinaryDataEncoding bde) {
@@ -58,6 +58,7 @@ public class BinaryDataEncoding extends DataEncoding {
         }
     }
 
+    @Override
     public Builder toBuilder() {
         return new Builder(this);
     }
@@ -107,6 +108,7 @@ public class BinaryDataEncoding extends DataEncoding {
             super();
         }
 
+        @Override
         public BinaryDataEncoding build() {
             return new BinaryDataEncoding(this);
         }

--- a/yamcs-xtce/src/main/java/org/yamcs/xtce/DataEncoding.java
+++ b/yamcs-xtce/src/main/java/org/yamcs/xtce/DataEncoding.java
@@ -12,16 +12,16 @@ import java.util.Set;
  * Describes how a particular piece of data is sent or received from some non-native, off-platform device. (e.g. a
  * spacecraft)
  * <p>
- *
+ * 
  * DIFFERS_FROM_XTCE: XTCE defines known encodings for the usual types (e.g. twosComplement for signed integers) and
  * allows
  * a catch all using a BinaryDataEncoding with a custom algorithm. We consider this approach as flawed and inconsistent:
  * whereas FloatDataEncoding converts from binary to float, IntegerDataEncoding converts from binary to integer, etc,
  * the BinaryDataEncoding would convert from binary to anything and it cannot be known into what by just looking at it.
- *
+ * 
  * Therefore in Yamcs we allow the catch all custom algorithm for all encodings and the BinaryDataEncoding can only
  * convert from binary to binary.
- *
+ * 
  *
  */
 public abstract class DataEncoding implements Serializable {
@@ -46,7 +46,7 @@ public abstract class DataEncoding implements Serializable {
 
     /**
      * copy constructor
-     *
+     * 
      * @param ide
      */
     DataEncoding(DataEncoding de) {
@@ -58,7 +58,7 @@ public abstract class DataEncoding implements Serializable {
 
     DataEncoding(Builder<?> builder, int defaultSizeInBits) {
         this.sizeInBits = defaultSizeInBits;
-
+        
         if (builder.sizeInBits != null) {
             this.sizeInBits = builder.sizeInBits;
         }
@@ -95,7 +95,7 @@ public abstract class DataEncoding implements Serializable {
      * Returns the size in bits of data encoded according to this encoding.
      * For some encodings like {@link StringDataEncoding} the size may be variable (depending on the data to be
      * encoded). In this cases it returns -1.
-     *
+     * 
      * @return size in bits or -1 if the size is unknown
      */
     public int getSizeInBits() {
@@ -126,7 +126,7 @@ public abstract class DataEncoding implements Serializable {
             out.writeInt(0);
         } else {
             out.writeInt(1);
-        }
+    }
     }
 
     private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
@@ -136,7 +136,7 @@ public abstract class DataEncoding implements Serializable {
             byteOrder = ByteOrder.BIG_ENDIAN;
         } else {
             byteOrder = ByteOrder.LITTLE_ENDIAN;
-        }
+    }
     }
 
     /**
@@ -167,7 +167,7 @@ public abstract class DataEncoding implements Serializable {
 
     /**
      * Create a shallow copy of the data encoding
-     *
+     * 
      * @return
      */
     public abstract DataEncoding copy();
@@ -204,7 +204,7 @@ public abstract class DataEncoding implements Serializable {
             this.fromBinaryTransformAlgorithm = alg;
             return self();
         }
-
+        
         public T setToBinaryTransformAlgorithm(Algorithm alg) {
             this.toBinaryTransformAlgorithm = alg;
             return self();

--- a/yamcs-xtce/src/main/java/org/yamcs/xtce/DynamicIntegerValue.java
+++ b/yamcs-xtce/src/main/java/org/yamcs/xtce/DynamicIntegerValue.java
@@ -5,7 +5,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Uses a parameter instance to obtain the value.
- * 
+ *
  * @author nm
  *
  */
@@ -13,26 +13,32 @@ public class DynamicIntegerValue extends IntegerValue {
     private static final long serialVersionUID = 201603101239L;
 
     transient static Logger log = LoggerFactory.getLogger(DynamicIntegerValue.class.getName());
-    ParameterInstanceRef instanceRef;;
+    ParameterOrArgumentRef instanceRef;
 
     public DynamicIntegerValue() {
     }
 
-    public DynamicIntegerValue(ParameterInstanceRef pir) {
-        this.instanceRef = pir;
-    }
-
-    public void setParameterInstanceRef(ParameterInstanceRef pir) {
-        this.instanceRef = pir;
+    public DynamicIntegerValue(ParameterOrArgumentRef ir) {
+        this.instanceRef = ir;
     }
 
     public ParameterInstanceRef getParameterInstnaceRef() {
+        if (!(instanceRef instanceof ParameterInstanceRef)) {
+            throw new IllegalStateException(
+                    "In DynamicIntegerValue: wanted ParameterInstanceRef but got "
+                            + instanceRef.getClass().getName());
+        }
+        return (ParameterInstanceRef) instanceRef;
+    }
+
+    public ParameterOrArgumentRef getDynamicInstanceRef() {
         return instanceRef;
     }
 
     @Override
     public String toString() {
-        return "DynamicIntegerValue(parameterInstance=" + instanceRef.getParameter().getName() + ")";
+        return "DynamicIntegerValue(instanceRef=" + instanceRef.getName()
+                + ")";
     }
 
 }

--- a/yamcs-xtce/src/main/java/org/yamcs/xtce/DynamicIntegerValue.java
+++ b/yamcs-xtce/src/main/java/org/yamcs/xtce/DynamicIntegerValue.java
@@ -5,7 +5,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Uses a parameter instance to obtain the value.
- *
+ * 
  * @author nm
  *
  */

--- a/yamcs-xtce/src/main/java/org/yamcs/xtce/xml/XtceStaxReader.java
+++ b/yamcs-xtce/src/main/java/org/yamcs/xtce/xml/XtceStaxReader.java
@@ -67,9 +67,9 @@ import static org.yamcs.xtce.XtceDb.*;
 
 /**
  * This class reads the XTCE XML files. XML document is accessed with the use of the Stax Iterator API.
- *
+ * 
  * @author mu
- *
+ * 
  */
 public class XtceStaxReader {
 
@@ -252,13 +252,13 @@ public class XtceStaxReader {
 
     /**
      * Reading of the XML XTCE file
-     *
+     * 
      * @param fileName
-     *
+     * 
      * @return returns the SpaceSystem read from the XML file
      * @throws XMLStreamException
      * @throws IOException
-     *
+     * 
      */
     public SpaceSystem readXmlDocument(String fileName) throws XMLStreamException, IOException, XtceLoadException {
         this.fileName = fileName;
@@ -317,7 +317,7 @@ public class XtceStaxReader {
 
     /**
      * * resolves references in ss by going recursively to all sub-space systems (in the first call ss=topSs)
-     *
+     * 
      * Return the number of reference resolved or -1 if there was nothing to resolve
      * <p>
      * Do not resolve references that start with the root container ("/a/b/c")
@@ -371,7 +371,7 @@ public class XtceStaxReader {
     /**
      * Method called on start document event. Currently just logs the information contained in the xml preamble of the
      * parsed file.
-     *
+     * 
      * @param start
      *            Start document event object
      */
@@ -382,7 +382,7 @@ public class XtceStaxReader {
     /**
      * Start of reading at the root of the document. According to the XTCE schema the root element is
      * &lt;SpaceSystem&gt;
-     *
+     * 
      * @throws XMLStreamException
      */
     private SpaceSystem readSpaceSystem() throws XMLStreamException {
@@ -433,7 +433,7 @@ public class XtceStaxReader {
 
     /**
      * Extraction of the AliasSet section Current implementation does nothing, just skips whole section
-     *
+     * 
      * @return Set of aliases defined for the object
      * @throws XMLStreamException
      */
@@ -460,7 +460,7 @@ public class XtceStaxReader {
 
     /**
      * Extraction of the AliasSet section Current implementation does nothing, just skips whole section
-     *
+     * 
      * @throws XMLStreamException
      */
     private void readAlias(XtceAliasSet aliasSet) throws XMLStreamException {
@@ -532,9 +532,9 @@ public class XtceStaxReader {
 
     /**
      * Extraction of the Header section Current implementation does nothing, just skips whole section
-     *
+     * 
      * @param spaceSystem
-     *
+     * 
      * @throws XMLStreamException
      */
     private void readHeader(SpaceSystem spaceSystem) throws XMLStreamException {
@@ -571,9 +571,9 @@ public class XtceStaxReader {
 
     /**
      * Extraction of the TelemetryMetaData section
-     *
+     * 
      * @param spaceSystem
-     *
+     * 
      * @throws XMLStreamException
      */
     private void readTelemetryMetaData(SpaceSystem spaceSystem) throws XMLStreamException {
@@ -1716,7 +1716,7 @@ public class XtceStaxReader {
 
     /**
      * Instantiate the SplineCalibrator element.
-     *
+     * 
      * @return
      * @throws XMLStreamException
      */
@@ -1739,7 +1739,7 @@ public class XtceStaxReader {
 
     /**
      * Instantiate SplinePoint element. This element has two required attributes: raw, calibrated
-     *
+     * 
      * @return
      * @throws XMLStreamException
      */
@@ -2099,7 +2099,7 @@ public class XtceStaxReader {
 
     /**
      * @param spaceSystem
-     *
+     * 
      */
     private void readParameterSet(SpaceSystem spaceSystem) throws IllegalStateException, XMLStreamException {
         log.trace(XTCE_PARAMETER_SET);
@@ -2121,7 +2121,7 @@ public class XtceStaxReader {
     }
 
     /**
-     *
+     * 
      * @return Parameter instance
      * @throws IllegalStateException
      * @throws XMLStreamException
@@ -2487,9 +2487,9 @@ public class XtceStaxReader {
 
     /**
      * Reads the definition of the containers
-     *
+     * 
      * @param spaceSystem
-     *
+     * 
      * @return
      * @throws IllegalStateException
      * @throws XMLStreamException
@@ -2917,15 +2917,15 @@ public class XtceStaxReader {
             ArgumentReference ref = ArgumentReference.getReference(metaCmd,
                     argRef);
 
-            ref.addResolvedAction((arg, path) -> {
-                argInstRef.setArgument(arg);
-                argInstRef.setMemberPath(path);
-                return true;
-            });
+        ref.addResolvedAction((arg, path) -> {
+            argInstRef.setArgument(arg);
+            argInstRef.setMemberPath(path);
+            return true;
+        });
 
-            if (!ref.isResolved()) {
-                spaceSystem.addUnresolvedReference(ref);
-            }
+        if (!ref.isResolved()) {
+            spaceSystem.addUnresolvedReference(ref);
+        }
         }
 
         argInstRef.setUseCalibratedValue(useCalibrated);
@@ -3074,7 +3074,7 @@ public class XtceStaxReader {
 
     /**
      * Just skips the whole section.
-     *
+     * 
      * @return
      * @throws IllegalStateException
      * @throws XMLStreamException
@@ -3086,7 +3086,7 @@ public class XtceStaxReader {
 
     /**
      * Just skips the whole section.
-     *
+     * 
      * @return
      * @throws IllegalStateException
      * @throws XMLStreamException
@@ -3098,9 +3098,9 @@ public class XtceStaxReader {
 
     /**
      * Just skips the whole section.
-     *
+     * 
      * @param spaceSystem
-     *
+     * 
      * @return
      * @throws IllegalStateException
      * @throws XMLStreamException
@@ -3150,9 +3150,9 @@ public class XtceStaxReader {
 
     /**
      * Extraction of the TelemetryMetaData section
-     *
+     * 
      * @param spaceSystem
-     *
+     * 
      * @throws XMLStreamException
      */
     private void readCommandMetaData(SpaceSystem spaceSystem) throws XMLStreamException {
@@ -3468,9 +3468,9 @@ public class XtceStaxReader {
 
     /**
      * Reads the definition of the command containers
-     *
+     * 
      * @param spaceSystem
-     *
+     * 
      * @return
      * @throws IllegalStateException
      */
@@ -3480,9 +3480,9 @@ public class XtceStaxReader {
 
     /**
      * Reads the definition of the metacommand containers
-     *
+     * 
      * @param spaceSystem
-     *
+     * 
      * @return
      * @throws IllegalStateException
      */
@@ -3631,7 +3631,7 @@ public class XtceStaxReader {
     }
 
     /**
-     *
+     * 
      * @return Parameter instance
      * @throws IllegalStateException
      * @throws XMLStreamException
@@ -4158,7 +4158,7 @@ public class XtceStaxReader {
 
     /**
      * Increase the skip statistics for the section.
-     *
+     * 
      * @param xtceSectionName
      *            Name of the skipped section.
      */
@@ -4186,7 +4186,7 @@ public class XtceStaxReader {
 
     /**
      * Skips whole section in the document.
-     *
+     * 
      * @param sectionName
      *            name of the section to skip
      * @throws XMLStreamException
@@ -4239,7 +4239,7 @@ public class XtceStaxReader {
     }
 
     /**
-     *
+     * 
      * @param filename
      * @return
      * @throws FileNotFoundException
@@ -4260,7 +4260,7 @@ public class XtceStaxReader {
 
     /**
      * Examines element for presence of attributes
-     *
+     * 
      * @param element
      *            Element to be examined, should not be null
      * @return True, if the element contains attributes, otherwise false
@@ -4276,7 +4276,7 @@ public class XtceStaxReader {
 
     /**
      * Check if xml element is a start element with particular name
-     *
+     * 
      * @param localName
      *            Name of the element
      * @return True if element is start element with the given name, otherwise false
@@ -4318,7 +4318,7 @@ public class XtceStaxReader {
     /**
      * Test if the xmlEvent is of type END_ELEMENT and has particular local name. This test is used to identify the end
      * of section.
-     *
+     * 
      * @param localName
      *            Local name of the element (we neglect namespace for now)
      * @return True if current xmlEvent is of type END_ELEMENT and has particular local name, otherwise false
@@ -4330,9 +4330,9 @@ public class XtceStaxReader {
 
     /**
      * Checks preconditions before the dedicated code for section reading will run
-     *
+     * 
      * @return
-     *
+     * 
      * @throws IllegalStateException
      *             If the conditions are not met
      */
@@ -4354,7 +4354,7 @@ public class XtceStaxReader {
 
     /**
      * Get attribute values as string
-     *
+     * 
      * @param attName
      *            Name of the attribute
      * @param element

--- a/yamcs-xtce/src/main/java/org/yamcs/xtce/xml/XtceStaxReader.java
+++ b/yamcs-xtce/src/main/java/org/yamcs/xtce/xml/XtceStaxReader.java
@@ -67,9 +67,9 @@ import static org.yamcs.xtce.XtceDb.*;
 
 /**
  * This class reads the XTCE XML files. XML document is accessed with the use of the Stax Iterator API.
- * 
+ *
  * @author mu
- * 
+ *
  */
 public class XtceStaxReader {
 
@@ -252,13 +252,13 @@ public class XtceStaxReader {
 
     /**
      * Reading of the XML XTCE file
-     * 
+     *
      * @param fileName
-     * 
+     *
      * @return returns the SpaceSystem read from the XML file
      * @throws XMLStreamException
      * @throws IOException
-     * 
+     *
      */
     public SpaceSystem readXmlDocument(String fileName) throws XMLStreamException, IOException, XtceLoadException {
         this.fileName = fileName;
@@ -317,7 +317,7 @@ public class XtceStaxReader {
 
     /**
      * * resolves references in ss by going recursively to all sub-space systems (in the first call ss=topSs)
-     * 
+     *
      * Return the number of reference resolved or -1 if there was nothing to resolve
      * <p>
      * Do not resolve references that start with the root container ("/a/b/c")
@@ -371,7 +371,7 @@ public class XtceStaxReader {
     /**
      * Method called on start document event. Currently just logs the information contained in the xml preamble of the
      * parsed file.
-     * 
+     *
      * @param start
      *            Start document event object
      */
@@ -382,7 +382,7 @@ public class XtceStaxReader {
     /**
      * Start of reading at the root of the document. According to the XTCE schema the root element is
      * &lt;SpaceSystem&gt;
-     * 
+     *
      * @throws XMLStreamException
      */
     private SpaceSystem readSpaceSystem() throws XMLStreamException {
@@ -433,7 +433,7 @@ public class XtceStaxReader {
 
     /**
      * Extraction of the AliasSet section Current implementation does nothing, just skips whole section
-     * 
+     *
      * @return Set of aliases defined for the object
      * @throws XMLStreamException
      */
@@ -460,7 +460,7 @@ public class XtceStaxReader {
 
     /**
      * Extraction of the AliasSet section Current implementation does nothing, just skips whole section
-     * 
+     *
      * @throws XMLStreamException
      */
     private void readAlias(XtceAliasSet aliasSet) throws XMLStreamException {
@@ -532,9 +532,9 @@ public class XtceStaxReader {
 
     /**
      * Extraction of the Header section Current implementation does nothing, just skips whole section
-     * 
+     *
      * @param spaceSystem
-     * 
+     *
      * @throws XMLStreamException
      */
     private void readHeader(SpaceSystem spaceSystem) throws XMLStreamException {
@@ -571,9 +571,9 @@ public class XtceStaxReader {
 
     /**
      * Extraction of the TelemetryMetaData section
-     * 
+     *
      * @param spaceSystem
-     * 
+     *
      * @throws XMLStreamException
      */
     private void readTelemetryMetaData(SpaceSystem spaceSystem) throws XMLStreamException {
@@ -1268,6 +1268,11 @@ public class XtceStaxReader {
                 IntegerValue v = readIntegerValue(spaceSystem);
                 if (v instanceof FixedIntegerValue) {
                     binaryDataEncoding.setSizeInBits((int) ((FixedIntegerValue) v).getValue());
+                } else if (v instanceof DynamicIntegerValue) {
+                    binaryDataEncoding.setSizeReference(
+                            ((DynamicIntegerValue) v).getDynamicInstanceRef());
+                    binaryDataEncoding
+                            .setType(BinaryDataEncoding.Type.DYNAMIC);
                 } else {
                     throwException("Only FixedIntegerValue supported for sizeInBits");
                 }
@@ -1711,7 +1716,7 @@ public class XtceStaxReader {
 
     /**
      * Instantiate the SplineCalibrator element.
-     * 
+     *
      * @return
      * @throws XMLStreamException
      */
@@ -1734,7 +1739,7 @@ public class XtceStaxReader {
 
     /**
      * Instantiate SplinePoint element. This element has two required attributes: raw, calibrated
-     * 
+     *
      * @return
      * @throws XMLStreamException
      */
@@ -2094,7 +2099,7 @@ public class XtceStaxReader {
 
     /**
      * @param spaceSystem
-     * 
+     *
      */
     private void readParameterSet(SpaceSystem spaceSystem) throws IllegalStateException, XMLStreamException {
         log.trace(XTCE_PARAMETER_SET);
@@ -2116,7 +2121,7 @@ public class XtceStaxReader {
     }
 
     /**
-     * 
+     *
      * @return Parameter instance
      * @throws IllegalStateException
      * @throws XMLStreamException
@@ -2482,9 +2487,9 @@ public class XtceStaxReader {
 
     /**
      * Reads the definition of the containers
-     * 
+     *
      * @param spaceSystem
-     * 
+     *
      * @return
      * @throws IllegalStateException
      * @throws XMLStreamException
@@ -2831,6 +2836,9 @@ public class XtceStaxReader {
             xmlEvent = xmlEventReader.nextEvent();
             if (isStartElementWithName(XTCE_PARAMETER_INSTANCE_REF)) {
                 v = new DynamicIntegerValue(readParameterInstanceRef(spaceSystem, null));
+            } else if (isStartElementWithName(XTCE_ARGUMENT_INSTANCE_REF)) {
+                v = new DynamicIntegerValue(
+                        readArgumentInstanceRef(spaceSystem, null));
             } else if (isEndElementWithName(XTCE_DYNAMIC_VALUE)) {
                 if (v == null) {
                     throw new XMLStreamException("No " + XTCE_PARAMETER_INSTANCE_REF + " section found");
@@ -2899,16 +2907,25 @@ public class XtceStaxReader {
         boolean useCalibrated = readBooleanAttribute("useCalibratedValue", startElement, true);
 
         ArgumentInstanceRef argInstRef = new ArgumentInstanceRef();
-        ArgumentReference ref = ArgumentReference.getReference(metaCmd, argRef);
+        // If we are not in the context of a metacommand, such as an argument
+        // that is used as the size of another argument type, then do not try
+        // to resolve the argument. Instead, the name alone will be used to
+        // look up the argument in context when needed.
+        if (metaCmd == null) {
+            argInstRef.setArgument(new Argument(argRef));
+        } else {
+            ArgumentReference ref = ArgumentReference.getReference(metaCmd,
+                    argRef);
 
-        ref.addResolvedAction((arg, path) -> {
-            argInstRef.setArgument(arg);
-            argInstRef.setMemberPath(path);
-            return true;
-        });
+            ref.addResolvedAction((arg, path) -> {
+                argInstRef.setArgument(arg);
+                argInstRef.setMemberPath(path);
+                return true;
+            });
 
-        if (!ref.isResolved()) {
-            spaceSystem.addUnresolvedReference(ref);
+            if (!ref.isResolved()) {
+                spaceSystem.addUnresolvedReference(ref);
+            }
         }
 
         argInstRef.setUseCalibratedValue(useCalibrated);
@@ -3057,7 +3074,7 @@ public class XtceStaxReader {
 
     /**
      * Just skips the whole section.
-     * 
+     *
      * @return
      * @throws IllegalStateException
      * @throws XMLStreamException
@@ -3069,7 +3086,7 @@ public class XtceStaxReader {
 
     /**
      * Just skips the whole section.
-     * 
+     *
      * @return
      * @throws IllegalStateException
      * @throws XMLStreamException
@@ -3081,9 +3098,9 @@ public class XtceStaxReader {
 
     /**
      * Just skips the whole section.
-     * 
+     *
      * @param spaceSystem
-     * 
+     *
      * @return
      * @throws IllegalStateException
      * @throws XMLStreamException
@@ -3133,9 +3150,9 @@ public class XtceStaxReader {
 
     /**
      * Extraction of the TelemetryMetaData section
-     * 
+     *
      * @param spaceSystem
-     * 
+     *
      * @throws XMLStreamException
      */
     private void readCommandMetaData(SpaceSystem spaceSystem) throws XMLStreamException {
@@ -3451,9 +3468,9 @@ public class XtceStaxReader {
 
     /**
      * Reads the definition of the command containers
-     * 
+     *
      * @param spaceSystem
-     * 
+     *
      * @return
      * @throws IllegalStateException
      */
@@ -3463,9 +3480,9 @@ public class XtceStaxReader {
 
     /**
      * Reads the definition of the metacommand containers
-     * 
+     *
      * @param spaceSystem
-     * 
+     *
      * @return
      * @throws IllegalStateException
      */
@@ -3614,7 +3631,7 @@ public class XtceStaxReader {
     }
 
     /**
-     * 
+     *
      * @return Parameter instance
      * @throws IllegalStateException
      * @throws XMLStreamException
@@ -4141,7 +4158,7 @@ public class XtceStaxReader {
 
     /**
      * Increase the skip statistics for the section.
-     * 
+     *
      * @param xtceSectionName
      *            Name of the skipped section.
      */
@@ -4169,7 +4186,7 @@ public class XtceStaxReader {
 
     /**
      * Skips whole section in the document.
-     * 
+     *
      * @param sectionName
      *            name of the section to skip
      * @throws XMLStreamException
@@ -4222,7 +4239,7 @@ public class XtceStaxReader {
     }
 
     /**
-     * 
+     *
      * @param filename
      * @return
      * @throws FileNotFoundException
@@ -4243,7 +4260,7 @@ public class XtceStaxReader {
 
     /**
      * Examines element for presence of attributes
-     * 
+     *
      * @param element
      *            Element to be examined, should not be null
      * @return True, if the element contains attributes, otherwise false
@@ -4259,7 +4276,7 @@ public class XtceStaxReader {
 
     /**
      * Check if xml element is a start element with particular name
-     * 
+     *
      * @param localName
      *            Name of the element
      * @return True if element is start element with the given name, otherwise false
@@ -4301,7 +4318,7 @@ public class XtceStaxReader {
     /**
      * Test if the xmlEvent is of type END_ELEMENT and has particular local name. This test is used to identify the end
      * of section.
-     * 
+     *
      * @param localName
      *            Local name of the element (we neglect namespace for now)
      * @return True if current xmlEvent is of type END_ELEMENT and has particular local name, otherwise false
@@ -4313,9 +4330,9 @@ public class XtceStaxReader {
 
     /**
      * Checks preconditions before the dedicated code for section reading will run
-     * 
+     *
      * @return
-     * 
+     *
      * @throws IllegalStateException
      *             If the conditions are not met
      */
@@ -4337,7 +4354,7 @@ public class XtceStaxReader {
 
     /**
      * Get attribute values as string
-     * 
+     *
      * @param attName
      *            Name of the attribute
      * @param element


### PR DESCRIPTION
This is probably insufficient, as I have not addressed exporting the XTCE. However, it
seems to support adequately both packet decoding and command encoding using
binary types that reference an associated parameter or argument for the encoding
length. It would be interesting to get your feedback.

I did this today on my own time, so this should be covered by the Contributor
License Agreement which I submitted previously.
<!--
Thank you for opening a Pull Request! Before submitting anything
non-trivial (more than a few lines), there are a few things you can
do to make sure it goes smoothly:

* Please start a discussion, before writing your code! That way we
  can discuss the change, evaluate designs, and agree on the general
  idea.

* You will need to sign a Contributor License Agreement (CLA):
  https://yamcs.org/static/Yamcs_Contributor_Agreement_v2.0.pdf

  You remain owner of your contribution, but in addition you give
  "Space Applications Services" the legal permission to use and
  distribute your contribution. This ensures that we can continue
  providing alternative licensing as a commercial feature.

Thanks again!
-->

