### PR TITLE
-Fixed javadoc tags. This was making mvn clean package fail

### DIFF
--- a/yamcs-core/src/main/java/org/yamcs/algorithms/AlgorithmExecutionResult.java
+++ b/yamcs-core/src/main/java/org/yamcs/algorithms/AlgorithmExecutionResult.java
@@ -10,13 +10,11 @@ import org.yamcs.parameter.RawEngValue;
  * The result of the algorithm execution consists of:
  * <ul>
  * <li>a list of input parameter values - optional - the list of parameters which have been used as input to the
- * algorithm.
- * <li>
- * <li>a list of output parameter values - these are {@link ParameterValue} which are then propagated to the Yamcs</li>
- * clients.
+ * algorithm.</li>
+ * <li>a list of output parameter values - these are {@link ParameterValue} which are then propagated to the Yamcs
+ * clients.</li>
  * <li>a return value - this is not an output parameter; used for command verifiers</li>
  * </ul>
- * 
  * 
  * @author nm
  *

--- a/yamcs-core/src/main/java/org/yamcs/algorithms/JavaExprAlgorithmExecutionFactory.java
+++ b/yamcs-core/src/main/java/org/yamcs/algorithms/JavaExprAlgorithmExecutionFactory.java
@@ -21,7 +21,7 @@ import org.yamcs.xtce.OutputParameter;
  * Each algorithm gets a class with the following body
  * 
  * <pre>
- * class AlgorithmExecutor_algoName extends AbstractAlgorithmExecutor {
+ * class AlgorithmExecutor_algoName extends AbstractAlgorithmExecutor {@code
  *     
  *     AlgorithmExecutionResult execute(long acqTime, long genTime) throws AlgorithmException {
  *        List<ParameterValue> outputValues = new ArrayList<>();

--- a/yamcs-core/src/main/java/org/yamcs/security/OpenIDAuthModule.java
+++ b/yamcs-core/src/main/java/org/yamcs/security/OpenIDAuthModule.java
@@ -28,8 +28,8 @@ import com.google.gson.JsonObject;
 
 /**
  * AuthModule that identifies users against an external identity provider compliant with OpenID Connect (OIDC).
- * 
- * @see https://openid.net/connect/
+ *
+ * @see <a href="https://openid.net/connect/">https://openid.net/connect/</a>
  */
 public class OpenIDAuthModule implements AuthModule {
 

--- a/yamcs-core/src/main/java/org/yamcs/time/TimeCorrelationService.java
+++ b/yamcs-core/src/main/java/org/yamcs/time/TimeCorrelationService.java
@@ -71,20 +71,20 @@ import org.yamcs.yarch.streamsql.StreamSqlStatement;
  * The determination of the gradient and offset is done using the least squares method.
  * <p>
  * The number of samples used for computing the coefficients is configurable and has to be minimum 2.
- * <p>
  * <h2>Accuracy and validity</h2>
  * Once the coefficients have been calculated, for each new sample received a deviation is calculated as the delta
  * between the OBT computed using the coefficients and the OBT which is part of the sample (after adjusting for
  * delays). The deviation is compared with the accuracy and validity parameters:
- * <p>
+ *
  * <ul>
  * <li>If the deviation is greater than {@code accuracy} but smaller than {@code validity}, then a recalculation of the
  * coefficients is performed based on the last received samples.</li>
- * <p>
+ *
  * <li>If the deviation is greater than {@code validity} then the coefficients are declared as invalid and all the
  * samples from the buffer except the last one are dropped. The time returned by {@link #getTime(long)} will be invalid
  * until
  * the required number of new samples is received and the next recalculation is performed</li>
+ * </ul>
  * 
  * <h2>Historical coefficients</h2>
  * The service keeps track of multiple intervals corresponding to different on-board time resets. At Yamcs startup

--- a/yamcs-core/src/main/java/org/yamcs/utils/IndexedList.java
+++ b/yamcs-core/src/main/java/org/yamcs/utils/IndexedList.java
@@ -27,7 +27,7 @@ public class IndexedList<K, V> implements Iterable<V> {
         values = new ArrayList<>(list.values);
         keys = new HashMap<>(list.keys);
     }
-    
+
     public IndexedList(int size) {
         values = new ArrayList<>(size);
         keys = new HashMap<>(size * 2);
@@ -67,6 +67,7 @@ public class IndexedList<K, V> implements Iterable<V> {
 
     /**
      * Returns the value mapped to the key or null if there is no such element
+     * 
      * @param key
      * @return
      */
@@ -79,7 +80,8 @@ public class IndexedList<K, V> implements Iterable<V> {
     }
 
     /**
-     * @see {@link List#get(int)}
+     * 
+     * @see List#get(int)
      * @param idx
      * @return
      */
@@ -87,7 +89,6 @@ public class IndexedList<K, V> implements Iterable<V> {
         return values.get(idx);
     }
 
-    
     @Override
     public Iterator<V> iterator() {
         return values.iterator();
@@ -101,11 +102,9 @@ public class IndexedList<K, V> implements Iterable<V> {
         return values.size();
     }
 
-   
-
     public void changeKey(K oldKey, K newKey) {
         Integer x = keys.remove(oldKey);
-        if(x==null) {
+        if (x==null) {
             throw new IllegalArgumentException("key inexistent");
         }
         keys.put(newKey, x);


### PR DESCRIPTION
When packaging yamcs by running `mvn package -Drelease -DskipTest` maven failed with the following error(s):

```
[ERROR] /home/lgomez/git/yamcs/yamcs-core/src/main/java/org/yamcs/utils/IndexedList.java:86: warning - Tag @see:illegal character: "64" in "{@link List#get(int)}"
[ERROR] /home/lgomez/git/yamcs/yamcs-core/src/main/java/org/yamcs/time/TimeCorrelationService.java:74: warning: empty <p> tag
[ERROR]  * <p>
[ERROR]    ^
[ERROR] /home/lgomez/git/yamcs/yamcs-core/src/main/java/org/yamcs/time/TimeCorrelationService.java:79: warning: empty <p> tag
[ERROR]  * <p>
[ERROR]    ^
[ERROR] /home/lgomez/git/yamcs/yamcs-core/src/main/java/org/yamcs/time/TimeCorrelationService.java:83: error: tag not allowed here: <p>
[ERROR]  * <p>
[ERROR]    ^
[ERROR] /home/lgomez/git/yamcs/yamcs-core/src/main/java/org/yamcs/time/TimeCorrelationService.java:83: warning: empty <p> tag
[ERROR]  * <p>
[ERROR]    ^
[ERROR] /home/lgomez/git/yamcs/yamcs-core/src/main/java/org/yamcs/time/TimeCorrelationService.java:89: error: tag not allowed here: <h2>
[ERROR]  * <h2>Historical coefficients</h2>
[ERROR]    ^
[ERROR] /home/lgomez/git/yamcs/yamcs-core/src/main/java/org/yamcs/time/TimeCorrelationService.java:89: error: text not allowed in <ul> element
[ERROR]  * <h2>Historical coefficients</h2>
[ERROR]                                    ^
[ERROR] /home/lgomez/git/yamcs/yamcs-core/src/main/java/org/yamcs/time/TimeCorrelationService.java:92: error: tag not allowed here: <p>
```

And there were a few more errors of the same kind. With this PR, those errors should go away.

Info on my environment:
```
NAME="Ubuntu"
VERSION="18.04.5 LTS (Bionic Beaver)"
ID=ubuntu
ID_LIKE=debian
PRETTY_NAME="Ubuntu 18.04.5 LTS"
VERSION_ID="18.04"
HOME_URL="https://www.ubuntu.com/"
SUPPORT_URL="https://help.ubuntu.com/"
BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
VERSION_CODENAME=bionic
UBUNTU_CODENAME=bionic
```

Output of `mvn --version`:
```
Apache Maven 3.6.0
Maven home: /usr/share/maven
Java version: 1.8.0_292, vendor: Private Build, runtime: /usr/lib/jvm/java-8-openjdk-amd64/jre
Default locale: en_US, platform encoding: UTF-8
OS name: "linux", version: "5.4.0-73-generic", arch: "amd64", family: "unix"

```


