### PR TITLE
File transfer Fixes and Suggestions

### DIFF
--- a/yamcs-core/src/main/java/org/yamcs/cfdp/CompletedTransfer.java
+++ b/yamcs-core/src/main/java/org/yamcs/cfdp/CompletedTransfer.java
@@ -90,10 +90,12 @@ public class CompletedTransfer implements CfdpFileTransfer {
     @Override
     public TransferDirection getDirection() {
         String str = tuple.getColumn(COL_DIRECTION);
-        try {
-            return TransferDirection.valueOf(str);
-        } catch (IllegalArgumentException e) {
-            log.warn("Unknown transfer direction {} retrieved from archive", str);
+        if (str != null) {
+            try {
+                return TransferDirection.valueOf(str);
+            } catch (IllegalArgumentException e) {
+                log.warn("Unknown transfer direction {} retrieved from archive", str);
+            }
         }
         return null;
     }
@@ -118,8 +120,8 @@ public class CompletedTransfer implements CfdpFileTransfer {
     @Override
     public CfdpTransactionId getTransactionId() {
         if (tuple.hasColumn(COL_SEQUENCE_NUMBER)) {
-        return new CfdpTransactionId(tuple.getLongColumn(COL_SOURCE_ID),
-                tuple.getIntColumn(COL_SEQUENCE_NUMBER));
+            return new CfdpTransactionId(tuple.getLongColumn(COL_SOURCE_ID),
+                    tuple.getIntColumn(COL_SEQUENCE_NUMBER));
         } else {
             return null;
         }
@@ -138,6 +140,13 @@ public class CompletedTransfer implements CfdpFileTransfer {
 
     @Override
     public boolean isReliable() {
+        Object isReliablResult = tuple.getColumn(COL_RELIABLE);
+
+        // NOTE: Maybe we should change the return types of methods in
+        // the FileTransfer interface to Optional instead of doing this.
+        if (isReliablResult == null) {
+            return false;
+        }
         return tuple.getColumn(COL_RELIABLE);
     }
 

--- a/yamcs-core/src/main/java/org/yamcs/http/api/FileTransferApi.java
+++ b/yamcs-core/src/main/java/org/yamcs/http/api/FileTransferApi.java
@@ -262,16 +262,20 @@ public class FileTransferApi extends AbstractFileTransferApi<Context> {
         }
     }
 
-    private static TransferInfo toTransferInfo(FileTransfer transfer) {
+    private static TransferInfo toTransferInfo(FileTransfer transfer) {        
         TransferInfo.Builder tib = TransferInfo.newBuilder()
                 .setId(transfer.getId())
                 .setState(transfer.getTransferState())
-                .setBucket(transfer.getBucketName())
-                .setDirection(transfer.getDirection())
                 .setTotalSize(transfer.getTotalSize())
                 .setSizeTransferred(transfer.getTransferredSize())
                 .setReliable(transfer.isReliable());
 
+        if (transfer.getDirection() != null) {
+            tib.setDirection(transfer.getDirection());
+        }
+        if (transfer.getBucketName() != null) {
+            tib.setBucket(transfer.getBucketName());
+        }
         if (transfer.getObjectName() != null) {
             tib.setObjectName(transfer.getObjectName());
         }


### PR DESCRIPTION
Hello everyone,

hope you are all doing well.

We recently have been using the FileTransfer  features of YAMCS, specifically CFDP with CFS. Most of the time it worked flawlessly. However recently we started to notice that whenever we would start a download by sending the `PlaybackFile` command to the vehicle, sometimes YAMCS Webapp would go into a state where the FileTransfer page became inaccessible. Specifically this happens when the `TXID[24_4]  transfer completed unsuccessfully: FILESTORE_REJECTION` event is published by CfdpService. So I started digging. And found that the server will throw an exception when a client(such as the Webapp) invoked the `org.yamcs.http.api.FileTransferApi.listTransfers(Context, ListTransfersRequest, Observer<ListTransfersResponse>)` function which is the function mapped to `/api/filetransfer/{instance}/{serviceName}/transfers` in the protobuf definitions.

The exception was a NullPointerException:

```
        org.yamcs.protobuf.TransferInfo$Builder.setBucket(TransferInfo.java:1525)
        org.yamcs.http.api.FileTransferApi.toTransferInfo(FileTransferApi.java:269)
        org.yamcs.http.api.FileTransferApi.subscribeTransfers(FileTransferApi.java:241)
        org.yamcs.http.api.FileTransferApi.subscribeTransfers(FileTransferApi.java:49)
        org.yamcs.protobuf.AbstractFileTransferApi.callMethod(AbstractFileTransferApi.java:160)
        org.yamcs.http.Topic.callMethod(Topic.java:57)
        org.yamcs.http.WebSocketFrameHandler.startNewContext(WebSocketFrameHandler.java:230)
        org.yamcs.http.WebSocketFrameHandler.channelRead0(WebSocketFrameHandler.java:141)
        org.yamcs.http.WebSocketFrameHandler.channelRead0(WebSocketFrameHandler.java:41)
        io.netty.channel.SimpleChannelInboundHandler.channelRead(SimpleChannelInboundHandler.java:99)
        io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
```

This is the error that this PR attempts to fix.
This fix 6eb4091a963ae2976efed0ecc4a62f73374b1686 might make sense to you guys. The Bucket can be null as documented [here](https://github.com/WindhoverLabs/yamcs/blob/master/yamcs-core/src/main/java/org/yamcs/filetransfer/FileTransfer.java#L7) , so I somewhat I understand why the bucket might be null. The change that I had to make because(after adding the Bucket null check) that I don't understand as much is this one 6efdd7e0c6a3f941494303e969b9539cc227a40a. It fixed all these issues I have encountered up until now. I guess I don't understand the CFDP API that much, but I hope you guys can put the pieces together as to why `tuple.getColumn(COL_RELIABLE);` might return null.



Hope these changes make sense.
Thanks
Lorenzo





