### PR TITLE
Fix issues with dropped transfer frames on a lossless link

### DIFF
--- a/yamcs-core/src/main/java/org/yamcs/tctm/ccsds/DownlinkTransferFrame.java
+++ b/yamcs-core/src/main/java/org/yamcs/tctm/ccsds/DownlinkTransferFrame.java
@@ -89,8 +89,10 @@ public abstract class DownlinkTransferFrame {
         if(vcFrameSeq == -1 ) {
             return -1;
         }
-        
-        long delta = prevFrameSeq < vcFrameSeq ? vcFrameSeq - prevFrameSeq :  vcFrameSeq + getSeqCountWrapArround() - prevFrameSeq;
+
+        long delta = prevFrameSeq < vcFrameSeq
+                   ? vcFrameSeq - prevFrameSeq
+                   : vcFrameSeq + getSeqCountWrapArround() - prevFrameSeq + 1;
         delta--;
         if (delta > getSeqInterruptionDelta()) {
             return -1;

--- a/yamcs-core/src/main/java/org/yamcs/tctm/ccsds/VcTmPacketHandler.java
+++ b/yamcs-core/src/main/java/org/yamcs/tctm/ccsds/VcTmPacketHandler.java
@@ -18,7 +18,7 @@ import org.yamcs.utils.YObjectLoader;
 
 /**
  * Handles packets from one VC
- * 
+ *
  * @author nm
  *
  */
@@ -74,8 +74,9 @@ public class VcTmPacketHandler implements TmPacketDataLink, VcDownlinkHandler {
 
         if (frame.containsOnlyIdleData()) {
             if (log.isTraceEnabled()) {
-                log.trace("Dropping idle frame for VC {}", frame.getVirtualChannelId());
+                log.trace("Dropping idle frame for VC {}, SEQ {}", frame.getVirtualChannelId(), frame.getVcFrameSeq());
             }
+            lastFrameSeq = frame.getVcFrameSeq();
             idleFrameCount++;
             return;
         }


### PR DESCRIPTION
This merge request fixes two small issues with TransferFrame sequence numbers.

The first issue was that the `lastFrameSeq` variable were not updated when idle frames were dropped, causing lost frames to be detected in cases where there were in fact no lost transfer frames.

The second issue was with wrap-around of sequence numbers where there were an off-by-one error in the calculation, causing some transfer frames to be dropped as a result.
