### PR TITLE
Allow specification of generation time in set parameter value requests

### DIFF
--- a/yamcs-api/src/main/proto/yamcs/protobuf/processing/processing.proto
+++ b/yamcs-api/src/main/proto/yamcs/protobuf/processing/processing.proto
@@ -318,6 +318,10 @@ message SetParameterValueRequest {
   
   // The new value.
   optional Value value = 4;
+
+  // The generation time of the value. If specified, must be a date
+  // string in ISO 8601 format.
+  optional google.protobuf.Timestamp generationTime = 5;
 }
 
 message BatchGetParameterValuesRequest {
@@ -342,6 +346,10 @@ message BatchSetParameterValuesRequest {
   message SetParameterValueRequest {
     optional NamedObjectId id = 1;
     optional Value value = 2;
+
+    // The generation time of the value. If specified, must be a date
+    // string in ISO 8601 format.
+    optional google.protobuf.Timestamp generationTime = 3;
   }
   
   // Yamcs instance name.

--- a/yamcs-core/src/main/java/org/yamcs/http/api/ProcessingApi.java
+++ b/yamcs-core/src/main/java/org/yamcs/http/api/ProcessingApi.java
@@ -280,6 +280,10 @@ public class ProcessingApi extends AbstractProcessingApi<Context> {
             pv = new PartialParameterValue(p, pid.getPath());
         }
         pv.setEngValue(v);
+        if (request.hasGenerationTime()) {
+            pv.setGenerationTime(TimeEncoding
+                    .fromProtobufTimestamp(request.getGenerationTime()));
+        }
         try {
             mgr.updateParameters(Arrays.asList(pv));
         } catch (IllegalArgumentException e) {
@@ -386,6 +390,10 @@ public class ProcessingApi extends AbstractProcessingApi<Context> {
                 pv = new PartialParameterValue(p, pid.getPath());
             }
             pv.setEngValue(ValueUtility.fromGpb(r.getValue()));
+            if (r.hasGenerationTime()) {
+                pv.setGenerationTime(TimeEncoding
+                        .fromProtobufTimestamp(r.getGenerationTime()));
+            }
             List<org.yamcs.parameter.ParameterValue> l = pvmap.computeIfAbsent(p.getDataSource(),
                     k -> new ArrayList<>());
             l.add(pv);


### PR DESCRIPTION
Modify BatchSetParameterValuesRequest.SetParameterValueRequest and
SetParameterValueRequest to have an optional generation time for the
new value. Modify processing API to use the generation time in the
request, if specified.


<!--
Thank you for opening a Pull Request! Before submitting anything
non-trivial (more than a few lines), there are a few things you can
do to make sure it goes smoothly:

* Please start a discussion, before writing your code! That way we
  can discuss the change, evaluate designs, and agree on the general
  idea.

* You will need to sign a Contributor License Agreement (CLA):
  https://yamcs.org/static/Yamcs_Contributor_Agreement_v2.0.pdf

  You remain owner of your contribution, but in addition you give
  "Space Applications Services" the legal permission to use and
  distribute your contribution. This ensures that we can continue
  providing alternative licensing as a commercial feature.

Thanks again!
-->

