### PR TITLE
replication: allow the server to reconnect, in case of a tcp link failure

### DIFF
--- a/yamcs-core/src/main/java/org/yamcs/replication/ReplicationSlave.java
+++ b/yamcs-core/src/main/java/org/yamcs/replication/ReplicationSlave.java
@@ -229,11 +229,13 @@ public class ReplicationSlave extends AbstractYamcsService {
      */
     public ChannelHandler newChannelHandler() throws YamcsException {
         if (slaveChannelHandler != null) {
-            throw new YamcsException("There is already a connection open to this slave");
+            log.warn("There is already a connection open to this slave, shutting it down.");
+            slaveChannelHandler.shutdown();           
         }
         slaveChannelHandler = new SlaveChannelHandler(this);
         return slaveChannelHandler;
     }
+
 
     public class SlaveChannelHandler extends ChannelInboundHandlerAdapter {
         ReplicationSlave replSlave;


### PR DESCRIPTION
replication: allow the server to reconnect, 
in case of a tcp link failure not yet noticed by the client.


<!--
Thank you for opening a Pull Request! Before submitting anything
non-trivial (more than a few lines), there are a few things you can
do to make sure it goes smoothly:

* Please start a discussion, before writing your code! That way we
  can discuss the change, evaluate designs, and agree on the general
  idea.

* You will need to sign a Contributor License Agreement (CLA):
  https://yamcs.org/static/Yamcs_Contributor_Agreement_v2.0.pdf

  You remain owner of your contribution, but in addition you give
  "Space Applications Services" the legal permission to use and
  distribute your contribution. This ensures that we can continue
  providing alternative licensing as a commercial feature.

Thanks again!
-->

