### PR TITLE
Fix #631: Add ability to use custom CLTU generator

### DIFF
--- a/docs/server-manual/links/ccsds-frame-processing.rst
+++ b/docs/server-manual/links/ccsds-frame-processing.rst
@@ -196,7 +196,7 @@ priorityScheme (string)
     One of ``FIFO``, ``ABSOLUTE`` or ``POLLING_VECTOR``. This configures the priority of the different Virtual Channels. The different schemes are described below.
     
 cltuEncoding (string)
-    One of ``BCH``, ``LDPC64`` or ``LDPC256``. If this parameter is present, the TC transfer frames will be encoded into CLTUs and this parameter configures the code to be used. If this parameter is not present, the frames will not be encapsulated into CLTUs and the following related parameters are ignored.
+    One of ``BCH``, ``LDPC64``, ``LDPC256``, or ``CUSTOM``. If this parameter is present, the TC transfer frames will be encoded into CLTUs and this parameter configures the code to be used. If this parameter is not present, the frames will not be encapsulated into CLTUs and the following related parameters are ignored. If the value is ``CUSTOM``, the CLTU generator class must be specified as indicated below.
 
 cltuStartSequence (string)
     This parameter can optionally set the  CLTU start sequence in hexadecimal if different than the CCSDS specs.
@@ -208,6 +208,12 @@ randomizeCltu (boolean)
     Used if cltuEncoding is BCH to enable/disable the randomization. For LDPC encoding, randomization is always on.
     Note that as per issue 4 of CCSDS 231.0 (TC Synchronization and Channel Coding), the randomization is done before the encoding when BCH is enabled whereas if LDPC encoding is enabled, the randomization is done after the encoding. This has been changed in Yamcs version 5.5.4 - in versions 5.5.3 and earlier the randomization was always applied before the encoding (as per issue 3 of the CCSDS standard).
  
+cltuGeneratorClassName (string)
+    **Required if cltuEncoding is CUSTOM.** Specifies the name of the class which constructs the CLTU from the frame, if a custom format is required.
+
+cltuGeneratorArgs
+    Optional if cltuEncoding is CUSTOM, ignored otherwise. Arguments to pass to the constructor for the CLTU generator classs.
+
 virtualChannels (map)
     **Required.** Used to specify the Virtual Channel specific configuration.
 
@@ -250,7 +256,7 @@ cop1TxLimit (integer)
     If COP-1 is enabled, this specifies the number of retransmissions for each un-acknolwedged frame before suspending operations.
            
 bdAbsolutePriority (false)
-    If COP-1 is enabled, this specifies that the BD frames have absolute priority over normal AD frames. This means that if there are a number of AD frames ready to be uplinked and a TC with ``cop1Bypass`` flag is received (see below for an explanation of this flag), it will pass in front of the queue so ti will be the first frame uplinked (once the multiplexer decides to uplink frames from this Virtual Channel). This flag only applies when the COP-1 state is active, if the COP-1 synchnoziation has not taken place, the BD frames are uplinked anyway (because all AD frames are waiting). 
+    If COP-1 is enabled, this specifies that the BD frames have absolute priority over normal AD frames. This means that if there are a number of AD frames ready to be uplinked and a TC with ``cop1Bypass`` flag is received (see below for an explanation of this flag), it will pass in front of the queue so ti will be the first frame uplinked (once the multiplexer decides to uplink frames from this Virtual Channel). This flag only applies when the COP-1 state is active, if the COP-1 synchronization has not taken place, the BD frames are uplinked anyway (because all AD frames are waiting). 
     
 
     

--- a/examples/ccsds-frames/src/main/java/org/yamcs/examples/ccsdsframes/SampleCltuGenerator.java
+++ b/examples/ccsds-frames/src/main/java/org/yamcs/examples/ccsdsframes/SampleCltuGenerator.java
@@ -1,0 +1,32 @@
+package org.yamcs.examples.ccsdsframes;
+
+import org.yamcs.YConfiguration;
+import org.yamcs.tctm.ccsds.error.CltuGenerator;
+
+/**
+ * Implements a CLTU generator that pads the CLTU to a multiple of a specified
+ * size. Note that the result is not a valid CCSDS TC CLTU. This processing is for
+ * example purposes only.
+ */
+public class SampleCltuGenerator extends CltuGenerator {
+
+	private int frameMultiple;
+
+	public SampleCltuGenerator() {
+		this(YConfiguration.emptyConfig());
+	}
+
+	public SampleCltuGenerator(YConfiguration config) {
+		super(null, null);
+		frameMultiple = config.getInt("frameMultiple", 128);
+	}
+
+	@Override
+	public byte[] makeCltu(byte[] data) {
+		int newLength = frameMultiple * ((data.length + frameMultiple - 1) / frameMultiple);
+		byte[] result = new byte[newLength];
+		System.arraycopy(data, 0, result, 0, data.length);
+		return result;
+	}
+
+}

--- a/examples/ccsds-frames/src/main/yamcs/etc/yamcs.ccsds-frames.yaml
+++ b/examples/ccsds-frames/src/main/yamcs/etc/yamcs.ccsds-frames.yaml
@@ -113,6 +113,29 @@ dataLinks:
             packetPreprocessorClassName: org.yamcs.tctm.IssPacketPreprocessor
             stream: "tm_dump"
           #vcId 63 is reserved for idle data and it does not have to be defined
+  - name: UDP_CUSTOM_CLTU_OUT
+    class: org.yamcs.tctm.ccsds.UdpTcFrameLink
+    enabledAtStartup: false
+    host: localhost #host and port where to send the frames to
+    port: 10019
+    spacecraftId: 0xAB
+    maxFrameLength: 1024
+    cltuEncoding: CUSTOM
+    cltuGeneratorClassName: org.yamcs.examples.ccsdsframes.SampleCltuGenerator
+    cltuGeneratorArgs:
+      frameMultiple: 256
+    virtualChannels:
+         - vcId: 0
+           service: "PACKET" 
+           commandPostprocessorClassName: org.yamcs.tctm.IssCommandPostprocessor
+           commandPostprocessorArgs:
+              errorDetection:
+                  type: 16-SUM
+              enforceEvenNumberOfBytes: true
+           stream: "tc_realtime" #which yamcs stream to get the data from
+           useCop1: true #enable FOP1 (the transmitter part of COP1, see CCSDS 232.1-B-2) for this VC
+           clcwStream: "clcw" #the name of the stream where the CLCW is received from, mandatory if FOP1 is used
+           initialClcwWait: 3600 #how many seconds to wait at startup for an initial CLCW, before going to state 6(initial). If not configured or negative, start directly in state 6
 
 mdb:
   # Configuration of the active loaders

--- a/yamcs-core/src/main/java/org/yamcs/tctm/ccsds/AbstractTcFrameLink.java
+++ b/yamcs-core/src/main/java/org/yamcs/tctm/ccsds/AbstractTcFrameLink.java
@@ -18,6 +18,7 @@ import org.yamcs.tctm.ccsds.error.CltuGenerator;
 import org.yamcs.tctm.ccsds.error.Ldpc256CltuGenerator;
 import org.yamcs.tctm.ccsds.error.Ldpc64CltuGenerator;
 import org.yamcs.utils.TimeEncoding;
+import org.yamcs.utils.YObjectLoader;
 
 /**
  * Sends TC as TC frames (CCSDS 232.0-B-3) or TC frames embedded in CLTU (CCSDS 231.0-B-3).
@@ -57,9 +58,20 @@ public abstract class AbstractTcFrameLink extends AbstractLink implements Aggreg
                 byte[] startSeq = config.getBinary(CLTU_START_SEQ_KEY, Ldpc256CltuGenerator.CCSDS_START_SEQ);
                 byte[] tailSeq = config.getBinary(CLTU_TAIL_SEQ_KEY, CltuGenerator.EMPTY_SEQ);
                 cltuGenerator = new Ldpc256CltuGenerator(startSeq, tailSeq);
+            } else if ("CUSTOM".equals(cltuEncoding)) {
+            	String cltuGeneratorClassName = config.getString("cltuGeneratorClassName", null);
+            	if (cltuGeneratorClassName == null) {
+            		throw new ConfigurationException("CUSTOM cltu generator requires value for cltuGeneratorClassName");
+            	}
+            	if (!config.containsKey("cltuGeneratorArgs")) {
+            		cltuGenerator = YObjectLoader.loadObject(cltuGeneratorClassName);
+            	} else {
+            		YConfiguration args = config.getConfig("cltuGeneratorArgs");
+            		cltuGenerator = YObjectLoader.loadObject(cltuGeneratorClassName, args);
+            	}
             } else {
                 throw new ConfigurationException(
-                        "Invalid value '" + cltuEncoding + " for cltu. Valid values are BCH, LDPC64 or LDPC256");
+                        "Invalid value '" + cltuEncoding + " for cltu. Valid values are BCH, LDPC64, LDPC256, or CUSTOM");
             }
         }
 

--- a/yamcs-core/src/main/java/org/yamcs/tctm/ccsds/error/CltuGenerator.java
+++ b/yamcs-core/src/main/java/org/yamcs/tctm/ccsds/error/CltuGenerator.java
@@ -14,7 +14,7 @@ public abstract class CltuGenerator {
     protected final byte[] tailSeq;
     
     public enum Encoding {
-        BCH, LDCP64, LDPC256
+        BCH, LDCP64, LDPC256, CUSTOM
     };
 
     public CltuGenerator(byte[] startSeq, byte[] tailSeq) {


### PR DESCRIPTION
Add "CUSTOM" option for the CLTU encoding when using TC frames. Add
ability to configure a custom CLTU encoder class and arguments. Modify
example configuration to show a data link using a custom encoder class.
Add sample custom CLTU encoder that just pads the frame to a specified
byte multiple boundary.


<!--
Thank you for opening a Pull Request! Before submitting anything
non-trivial (more than a few lines), there are a few things you can
do to make sure it goes smoothly:

* Please start a discussion, before writing your code! That way we
  can discuss the change, evaluate designs, and agree on the general
  idea.

* You will need to sign a Contributor License Agreement (CLA):
  https://yamcs.org/static/Yamcs_Contributor_Agreement_v2.0.pdf

  You remain owner of your contribution, but in addition you give
  "Space Applications Services" the legal permission to use and
  distribute your contribution. This ensures that we can continue
  providing alternative licensing as a commercial feature.

Thanks again!
-->

