### PR TITLE
Add EarthReceptionTime in FilePollingTmDataLink class (yamcs#711)

### DIFF
--- a/yamcs-core/src/main/java/org/yamcs/tctm/FilePollingTmDataLink.java
+++ b/yamcs-core/src/main/java/org/yamcs/tctm/FilePollingTmDataLink.java
@@ -15,6 +15,7 @@ import org.yamcs.ConfigurationException;
 import org.yamcs.TmPacket;
 import org.yamcs.YConfiguration;
 import org.yamcs.YamcsServer;
+import org.yamcs.time.Instant;
 import org.yamcs.utils.TimeEncoding;
 import org.yamcs.utils.YObjectLoader;
 
@@ -95,6 +96,7 @@ public class FilePollingTmDataLink extends AbstractTmDataLink implements Runnabl
     }
 
     private void play(File fdir) throws InterruptedException {
+        Instant erp = timeService.getHresMissionTime();
         File[] files = fdir.listFiles();
         Arrays.sort(files);
         for (File f : files) {
@@ -112,7 +114,9 @@ public class FilePollingTmDataLink extends AbstractTmDataLink implements Runnabl
                 byte[] packet;
                 while ((packet = packetInputStream.readPacket()) != null) {
                     updateStats(packet.length);
-                    TmPacket tmpkt = packetPreprocessor.process(new TmPacket(timeService.getMissionTime(), packet));
+                    TmPacket tmPacket = new TmPacket(timeService.getMissionTime(), packet);
+                    tmPacket.setEarthRceptionTime(erp);
+                    TmPacket tmpkt = packetPreprocessor.process(tmPacket);
                     minTime = Math.min(minTime, tmpkt.getGenerationTime());
                     maxTime = Math.max(maxTime, tmpkt.getGenerationTime());
                     count++;


### PR DESCRIPTION
This PR adds the EarthReceptionTime to a TM packet in the FilePollingTmDataLink class.

After applying this, the code executed nominaly:

Yamcs v5.7.7-SNAPSHOT
```
timeEncoding:
  type: CUC
  epoch: NONE
```
gives
```
11:10:44.017 fakesat [26] FilePollingTmDataLink [tm-file-polling] Injecting the content of yamcs-incoming/fakesat/tm/TLM-sample.dat
11:10:44.024 fakesat [26] FilePollingTmDataLink [tm-file-polling] yamcs-incoming/fakesat/tm/TLM-sample.dat finished
11:10:44.025 _global [26] EventProducer event: INFO; FILE_INGESTION; Ingested yamcs-incoming/fakesat/tm/TLM-sample.dat; pkt count: 1, time range: [2022-08-24T09:10:43.017Z, 2022-08-24T09:10:43.017Z]
```
and with
```
timeEncoding:
  type: CUC
  epoch: TAI
```
gives
```
11:12:08.007 fakesat [26] FilePollingTmDataLink [tm-file-polling] Injecting the content of yamcs-incoming/fakesat/tm/TLM-sample.dat
11:12:08.023 fakesat [26] FilePollingTmDataLink [tm-file-polling] yamcs-incoming/fakesat/tm/TLM-sample.dat finished
11:12:08.025 _global [26] EventProducer event: INFO; FILE_INGESTION; Ingested yamcs-incoming/fakesat/tm/TLM-sample.dat; pkt count: 1, time range: [2022-08-24T09:12:07.007Z, 2022-08-24T09:12:07.007Z]
```

I sampled the ERT at the beginning of the function, because that will be the earliest point there we "received" the telemetry data. By that time all the files would be on the disk and be ready for processing.  If the time collection is placed inside the processing loop, then the ERT will include the processing time of the files, which I think is not the right thing to do.
