### PR TITLE
Update CFDP Packet class with CRC support

### DIFF
--- a/yamcs-core/src/main/java/org/yamcs/tctm/ccsds/error/Crc16Calculator.java
+++ b/yamcs-core/src/main/java/org/yamcs/tctm/ccsds/error/Crc16Calculator.java
@@ -1,5 +1,7 @@
 package org.yamcs.tctm.ccsds.error;
 
+import java.nio.ByteBuffer;
+
 public class Crc16Calculator {
     final int polynomial;
     short r[] = new short[256];
@@ -36,5 +38,16 @@ public class Crc16Calculator {
 
         return crc & 0xFFFF;
 
+    }
+
+    public int compute(ByteBuffer bb, int offset, int length, int initialValue) {
+        int crc = initialValue;
+
+        for (int i = offset; i < offset + length; i++) {
+            int idx = (bb.get(i) ^ (crc >> 8)) & 0xff;
+            crc = r[idx] ^ (crc << 8);
+        }
+
+        return crc & 0xFFFF;
     }
 }

--- a/yamcs-core/src/main/java/org/yamcs/tctm/ccsds/error/CrcCciitCalculator.java
+++ b/yamcs-core/src/main/java/org/yamcs/tctm/ccsds/error/CrcCciitCalculator.java
@@ -1,5 +1,7 @@
 package org.yamcs.tctm.ccsds.error;
 
+import java.nio.ByteBuffer;
+
 import org.yamcs.YConfiguration;
 import org.yamcs.tctm.ErrorDetectionWordCalculator;
 
@@ -28,7 +30,10 @@ public class CrcCciitCalculator implements ErrorDetectionWordCalculator {
     @Override
     public int compute(byte[] data, int offset, int length) {
         return cc.compute(data, offset, length, initialValue);
+    }
 
+    public int compute(ByteBuffer data, int offset, int length) {
+        return cc.compute(data, offset, length, initialValue);
     }
 
     @Override


### PR DESCRIPTION
The current CFDP Packet class throw an UnsupportedOperationException when it receive packets with the CRC bit being set. Due to a noisy radio link, we have to set the CRC bit on CFDP frames for our satellite's downlink. But due to this unimplemented feature Yamcs is unable to process the packets.

This PR updates the CfdpPacket class to check the CRC if `.withCrc()` method returns true and throws a PduDecodingException to indicate that the CRC checksum is invalid. 

The toByteArray() and writeToBuffer() methods has been updated to add the CRC at the end of the buffer when the `.withCrc()` method returns true. 

Lastly the Crc16Calculator class updated to add an `compute` overload to work directly on a ByteBuffer instead of a byte array.