### PR TITLE
Use Spec.ANY as the default spec for Spec options

### DIFF
--- a/yamcs-core/src/main/java/org/yamcs/Spec.java
+++ b/yamcs-core/src/main/java/org/yamcs/Spec.java
@@ -251,12 +251,12 @@ public class Spec {
             }
 
             if (!specified) {
+                var path = "".equals(parent) ? option.name : parent + "->" + option.name;
                 if (option.required) {
-                    var path = "".equals(parent) ? option.name : parent + "->" + option.name;
                     throw new ValidationException(ctx, "Missing required argument " + path);
                 }
 
-                var defaultValue = option.computeDefaultValue();
+                var defaultValue = option.validate(ctx, option.computeDefaultValue(), path);
                 if (defaultValue != null) {
                     result.put(option.name, defaultValue);
                 }

--- a/yamcs-core/src/main/java/org/yamcs/Spec.java
+++ b/yamcs-core/src/main/java/org/yamcs/Spec.java
@@ -665,6 +665,12 @@ public class Spec {
                         "%s should be one of %s", name, choices));
             }
 
+            if (type == OptionType.MAP || ((type == OptionType.LIST || type == OptionType.LIST_OR_ELEMENT) && elementType == OptionType.MAP)) {
+                if (spec == null) {
+                    throw new ValidationException(ctx, String.format("%s cannot be validated since it does not have a specification. This is a bug in the class that the configuration applies to.", path));
+                }
+            }
+
             if (type == OptionType.LIST || type == OptionType.LIST_OR_ELEMENT) {
                 var resultList = new ArrayList<>();
                 var it = ((List<Object>) arg).listIterator();

--- a/yamcs-core/src/main/java/org/yamcs/filetransfer/CsvListingParser.java
+++ b/yamcs-core/src/main/java/org/yamcs/filetransfer/CsvListingParser.java
@@ -55,10 +55,10 @@ public class CsvListingParser extends FileListingParser {
         Spec spec = new Spec();
         spec.addOption("useCsvHeader", OptionType.BOOLEAN).withDefault(false);
         spec.addOption("timestampMultiplier", OptionType.FLOAT).withDefault(1000);
-        spec.addOption("protobufColumnNumberMapping", OptionType.MAP).withDefault(new HashMap<>( // Default: protobuf order
+        spec.addOption("protobufColumnNumberMapping", OptionType.MAP).withSpec(Spec.ANY).withDefault(new HashMap<>( // Default: protobuf order
                     RemoteFile.getDescriptor().getFields().stream()
                             .collect(Collectors.toMap(Descriptors.FieldDescriptor::getName,fieldDescriptor -> fieldDescriptor.getNumber() - 1))));
-        spec.addOption("headerProtobufMapping", OptionType.MAP).withDefault(new HashMap<>( // Default: assumes same names as protobuf
+        spec.addOption("headerProtobufMapping", OptionType.MAP).withSpec(Spec.ANY).withDefault(new HashMap<>( // Default: assumes same names as protobuf
                         RemoteFile.getDescriptor().getFields().stream()
                                 .collect(Collectors.toMap(Descriptors.FieldDescriptor::getName, Descriptors.FieldDescriptor::getName))));
         return spec;


### PR DESCRIPTION
Without this Spec$Option.validate will run into a NullPointerException when validating the option if the element that the spec belongs to forgot to use `withSpec(Spec.ANY)` (which is the case for the CsvListingParser options but there may be other cases)

Here is a small patch to the cfdp example configuration that will trigger the mentioned NullPointerException

```
diff --git a/examples/cfdp-udp/src/main/yamcs/etc/yamcs.cfdp.yaml b/examples/cfdp-udp/src/main/yamcs/etc/yamcs.cfdp.yaml
index a766b048f..8b1623986 100644
--- a/examples/cfdp-udp/src/main/yamcs/etc/yamcs.cfdp.yaml
+++ b/examples/cfdp-udp/src/main/yamcs/etc/yamcs.cfdp.yaml
@@ -31,6 +31,14 @@ services:
   - class: org.yamcs.cfdp.CfdpService
     name: cfdp0
     args:
+     fileListingParserClassName: org.yamcs.filetransfer.CsvListingParser
+     fileListingParserArgs:
+       useCsvHeader: true
+       headerProtobufMapping:
+         path: name
+         isDirectory: isDirectory
+         size: size
+         timestamp: modified
      inactivityTimeout: 30000
      sequenceNrLength: 4
      maxPduSize: 512
```