### PR TITLE
Add NullPointerException to try/catch in CompletedTransfer.getDirection() method

### DIFF
--- a/yamcs-core/src/main/java/org/yamcs/cfdp/CompletedTransfer.java
+++ b/yamcs-core/src/main/java/org/yamcs/cfdp/CompletedTransfer.java
@@ -15,7 +15,7 @@ import org.yamcs.yarch.TupleDefinition;
  * the database).
  * <p>
  * Implements also some methods for converting between on-going transfers and tuples.
- * 
+ *
  * @author nm
  *
  */
@@ -97,6 +97,8 @@ public class CompletedTransfer implements CfdpFileTransfer {
             return TransferDirection.valueOf(str);
         } catch (IllegalArgumentException e) {
             log.warn("Unknown transfer direction {} retrieved from archive", str);
+        } catch (NullPointerException e) {
+            log.warn("Transfer direction retrieved from archive was NULL");
         }
         return null;
     }


### PR DESCRIPTION
Updated the `CompletedTransfer.getDirection()` method to add a `NullPointerException` to the try/catch statement to handle situcations where the database contains a `NULL` in the `direction` column of the `cfdp` table.  Without this fix the method will throw an exception if a `NULL` is loaded from the database and cause the connection to the Web interface to be close. That has the effect that the `File Transfer` tab in the web interface becomes unusable.

Related to issue yamcs#847