### PR TITLE
Add a new AlgorithmReference.java class to resolve fetching an algorithm that belongs to another spaceSystem

### DIFF
--- a/yamcs-core/src/main/java/org/yamcs/mdb/BaseSpreadsheetLoader.java
+++ b/yamcs-core/src/main/java/org/yamcs/mdb/BaseSpreadsheetLoader.java
@@ -14,6 +14,7 @@ import org.yamcs.ConfigurationException;
 import org.yamcs.mdb.ConditionParser.ParameterReferenceFactory;
 import org.yamcs.xtce.SpaceSystem;
 import org.yamcs.xtce.ValueEnumeration;
+import org.yamcs.xtce.util.AlgorithmReference;
 import org.yamcs.xtce.util.NameReference;
 import org.yamcs.xtce.util.ParameterReference;
 
@@ -347,6 +348,13 @@ public abstract class BaseSpreadsheetLoader extends AbstractFileLoader {
         spaceSystem.addUnresolvedReference(paraRef);
 
         return paraRef;
+    }
+
+    public static AlgorithmReference getAlgorithmReference(SpaceSystem ss, String algoName) {
+        AlgorithmReference algoRef = new AlgorithmReference(algoName);
+        ss.addUnresolvedReference(algoRef);
+
+        return algoRef;
     }
 
     protected void validateNameType(String name) {

--- a/yamcs-xtce/src/main/java/org/yamcs/xtce/util/AlgorithmReference.java
+++ b/yamcs-xtce/src/main/java/org/yamcs/xtce/util/AlgorithmReference.java
@@ -1,0 +1,48 @@
+package org.yamcs.xtce.util;
+
+import org.yamcs.xtce.Algorithm;
+import org.yamcs.xtce.NameDescription;
+
+
+public class AlgorithmReference extends NameReference {
+    @FunctionalInterface
+    public interface AlgorithmResolvedAction extends ResolvedAction {
+        /**
+         * pushes the NameDescription through and returns true if the name reference is resolved and false otherwise
+         * 
+         * false can be returned in case the NameDescription refers to something which is not itself fully resolved
+         */
+        public void resolved(Algorithm algo);
+
+        default void resolved(NameDescription nd) {
+            resolved((Algorithm) nd);
+        }
+
+    }
+
+    public AlgorithmReference(String ref) {
+        super(ref, Type.ALGORITHM);
+    }
+
+    public void resolved(Algorithm algorithm) {
+        result = algorithm;
+
+        for (ResolvedAction ra : actions) {
+            if (ra instanceof AlgorithmResolvedAction) {
+                ((AlgorithmResolvedAction) ra).resolved(algorithm);
+            } else {
+                ra.resolved(algorithm);
+            }
+        }
+    }
+
+    public AlgorithmReference addResolvedAction(AlgorithmResolvedAction action) {
+        if (result == null) {
+            actions.add(action);
+        } else {
+            action.resolved((Algorithm) result);
+        }
+
+        return this;
+    }
+}

--- a/yamcs-xtce/src/main/java/org/yamcs/xtce/util/ReferenceFinder.java
+++ b/yamcs-xtce/src/main/java/org/yamcs/xtce/util/ReferenceFinder.java
@@ -376,7 +376,10 @@ public class ReferenceFinder {
                 ((ParameterReference) nr).resolved((Parameter) nd, aggregateMemberPath);
             } else if (nr instanceof ArgumentReference) {
                 ((ArgumentReference) nr).resolved((Argument) nd, aggregateMemberPath);
-            } else {
+            } else if (nr instanceof AlgorithmReference) {
+                ((AlgorithmReference) nr).resolved(nd);
+            } 
+            else {
                 nr.resolved(nd);
             }
         }


### PR DESCRIPTION
Currently, it is only possible to reference the commandVerifierAlgorithms when defined within the same spaceSystem where the commandVerifier is defined.

This PR allows one to reference algorithms from other spaceSystems as well.
Referencing parameters within an algorithm that belong to different spaceSystems has already been implemented.

@xpromache @fqqb , I have currently made the PR w.r.t commandVerifierAlgorithms only. Please review the changes.

I can extend this idea to the commandVerifierContainers as well.