### PR TITLE
Fix NullPointerException in FilePollingTmDataLink class

### DIFF
--- a/yamcs-core/src/main/java/org/yamcs/tctm/FilePollingTmDataLink.java
+++ b/yamcs-core/src/main/java/org/yamcs/tctm/FilePollingTmDataLink.java
@@ -156,10 +156,12 @@ public class FilePollingTmDataLink extends AbstractTmDataLink implements Runnabl
                     tmPacket = new TmPacket(timeService.getMissionTime(), packet);
                     tmPacket.setEarthReceptionTime(erp);
                     tmPacket = packetPreprocessor.process(tmPacket);
-                    minTime = Math.min(minTime, tmPacket.getGenerationTime());
-                    maxTime = Math.max(maxTime, tmPacket.getGenerationTime());
-                    count++;
-                    processPacket(tmPacket);
+                    if (tmPacket != null) {
+                        minTime = Math.min(minTime, tmPacket.getGenerationTime());
+                        maxTime = Math.max(maxTime, tmPacket.getGenerationTime());
+                        count++;
+                        processPacket(tmPacket);
+                    }
                     if (delayBetweenPackets > 0) {
                         Thread.sleep(delayBetweenPackets);
                     }


### PR DESCRIPTION
In the `play()` function of the `FilePollingTmDataLink` class, the code call the `process()` function of the `packetPreprocessor` instance. In our case, we use the `PusPacketPreprocessor` class to process files with ECSS/PUS formatted packets. That `process()` function has 4 return statements that return a `null`.  Returning a `null` cause a `NullPointerException` to be thown; which in turn will cause the `FilePollingTmDataLink` class's processing thread to terminate and the class stops processing any more files. On our production server, we had to manually find and remove the offending file and then restart the polling link before any more processing could happen.

This PR adds a check for the `null`, thus discarding that one packet and keeps the `FilePollingTmDataLink` active in cases of errors in a file.