### PR TITLE
Count invalid frames in AbstractTmFrameLink

### DIFF
--- a/yamcs-core/src/main/java/org/yamcs/tctm/ccsds/AbstractTmFrameLink.java
+++ b/yamcs-core/src/main/java/org/yamcs/tctm/ccsds/AbstractTmFrameLink.java
@@ -19,7 +19,7 @@ import org.yamcs.time.Instant;
 public abstract class AbstractTmFrameLink extends AbstractLink implements AggregatedDataLink {
     protected List<Link> subLinks;
     protected MasterChannelFrameHandler frameHandler;
-    protected AtomicLong frameCount = new AtomicLong(0);
+    protected AtomicLong validFrameCount = new AtomicLong(0);
     protected AtomicLong invalidFrameCount = new AtomicLong(0);
 
     protected long errFrameCount;
@@ -119,7 +119,7 @@ public abstract class AbstractTmFrameLink extends AbstractLink implements Aggreg
 
             frameHandler.handleFrame(ert, data, offset, length);
 
-            frameCount.getAndIncrement();
+            validFrameCount.getAndIncrement();
         } catch (TcTmException e) {
             eventProducer.sendWarning("Error processing frame: " + e.toString());
             invalidFrameCount.getAndIncrement();
@@ -134,7 +134,7 @@ public abstract class AbstractTmFrameLink extends AbstractLink implements Aggreg
     @Override
     public void resetCounters() {
         super.resetCounters();
-        frameCount.set(0);
+        validFrameCount.set(0);
         invalidFrameCount.set(0);
     }
 

--- a/yamcs-core/src/main/java/org/yamcs/tctm/ccsds/UdpTmFrameLink.java
+++ b/yamcs-core/src/main/java/org/yamcs/tctm/ccsds/UdpTmFrameLink.java
@@ -108,7 +108,7 @@ public class UdpTmFrameLink extends AbstractTmFrameLink implements Runnable {
     @Override
     public Map<String, Object> getExtraInfo() {
         var extra = new LinkedHashMap<String, Object>();
-        extra.put("Valid frames", frameCount.get());
+        extra.put("Valid frames", validFrameCount.get());
         extra.put("Invalid frames", invalidFrameCount.get());
         return extra;
     }

--- a/yamcs-core/src/main/java/org/yamcs/tctm/ccsds/UdpTmFrameLink.java
+++ b/yamcs-core/src/main/java/org/yamcs/tctm/ccsds/UdpTmFrameLink.java
@@ -21,8 +21,6 @@ import org.yamcs.utils.StringConverter;
  *
  */
 public class UdpTmFrameLink extends AbstractTmFrameLink implements Runnable {
-    private volatile int invalidDatagramCount = 0;
-
     private DatagramSocket tmSocket;
     private int port;
 
@@ -111,14 +109,8 @@ public class UdpTmFrameLink extends AbstractTmFrameLink implements Runnable {
     public Map<String, Object> getExtraInfo() {
         var extra = new LinkedHashMap<String, Object>();
         extra.put("Valid datagrams", frameCount.get());
-        extra.put("Invalid datagrams", invalidDatagramCount);
+        extra.put("Invalid datagrams", invalidFrameCount.get());
         return extra;
-    }
-
-    @Override
-    public void resetCounters() {
-        super.resetCounters();
-        invalidDatagramCount = 0;
     }
 
     @Override

--- a/yamcs-core/src/main/java/org/yamcs/tctm/ccsds/UdpTmFrameLink.java
+++ b/yamcs-core/src/main/java/org/yamcs/tctm/ccsds/UdpTmFrameLink.java
@@ -108,8 +108,8 @@ public class UdpTmFrameLink extends AbstractTmFrameLink implements Runnable {
     @Override
     public Map<String, Object> getExtraInfo() {
         var extra = new LinkedHashMap<String, Object>();
-        extra.put("Valid datagrams", frameCount.get());
-        extra.put("Invalid datagrams", invalidFrameCount.get());
+        extra.put("Valid frames", frameCount.get());
+        extra.put("Invalid frames", invalidFrameCount.get());
         return extra;
     }
 


### PR DESCRIPTION
I noticed that the "Valid Datagrams" and "Invalid Datagrams" in the UdpTmFrameLink are not very useful right now since AbstractTmFrameLink increments frameCount before actually trying to decode the frame (which means that even frames with a corrupted header or an invalid FECF are counted in "Valid Datagrams".

Additionally, the frameCount was not reset in resetCounters() so I added this as well.

Let me know if I should add a test case for this somewhere.
