### PR TITLE
Add argument type's name to the argument info

### DIFF
--- a/yamcs-api/src/main/proto/yamcs/protobuf/mdb/mdb.proto
+++ b/yamcs-api/src/main/proto/yamcs/protobuf/mdb/mdb.proto
@@ -501,6 +501,9 @@ message ArgumentTypeInfo {
 
   // Type of array entries (only used by array arguments)
   optional ArgumentTypeInfo elementType = 17;
+
+  // Name of the parameter type
+  optional string name = 18;
 }
 
 message ArgumentDimensionInfo {

--- a/yamcs-core/src/main/java/org/yamcs/http/api/XtceToGpbAssembler.java
+++ b/yamcs-core/src/main/java/org/yamcs/http/api/XtceToGpbAssembler.java
@@ -900,7 +900,9 @@ public class XtceToGpbAssembler {
     public static ArgumentTypeInfo toArgumentTypeInfo(ArgumentType argumentType) {
         ArgumentTypeInfo.Builder infob = ArgumentTypeInfo.newBuilder()
                 .setEngType(argumentType.getTypeAsString());
-        infob.setName(argumentType.getName());
+        if (argumentType.getName() != null) {
+            infob.setName(argumentType.getName());
+        }
 
         if (argumentType instanceof BaseDataType) {
             BaseDataType bdt = (BaseDataType) argumentType;

--- a/yamcs-core/src/main/java/org/yamcs/http/api/XtceToGpbAssembler.java
+++ b/yamcs-core/src/main/java/org/yamcs/http/api/XtceToGpbAssembler.java
@@ -900,6 +900,7 @@ public class XtceToGpbAssembler {
     public static ArgumentTypeInfo toArgumentTypeInfo(ArgumentType argumentType) {
         ArgumentTypeInfo.Builder infob = ArgumentTypeInfo.newBuilder()
                 .setEngType(argumentType.getTypeAsString());
+        infob.setName(argumentType.getName());
 
         if (argumentType instanceof BaseDataType) {
             BaseDataType bdt = (BaseDataType) argumentType;


### PR DESCRIPTION
Added the argument type's name from the MDb to the ArgumentTypeInfo proto. Looks like the parameter type's name does appear to be a part of the ParameterTypeInfo, but not ArgumentTypeInfo.
