### PR TITLE
yamcs-xtce: Add support for IndirectParameterRefEntry

### DIFF
--- a/yamcs-core/src/test/java/org/yamcs/mdb/IndirectParameterRefBinaryDecodingTest.java
+++ b/yamcs-core/src/test/java/org/yamcs/mdb/IndirectParameterRefBinaryDecodingTest.java
@@ -1,0 +1,73 @@
+package org.yamcs.mdb;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.net.URISyntaxException;
+
+import javax.xml.stream.XMLStreamException;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.yamcs.YConfiguration;
+import org.yamcs.parameter.ParameterValueList;
+import org.yamcs.utils.TimeEncoding;
+import org.yamcs.xtce.xml.XtceLoadException;
+
+/**
+ * Tests that a packet containing indirect parameter entry can be decoded correctly.
+ */
+public class IndirectParameterRefBinaryDecodingTest {
+
+    private static final String ID_QN = "/Example/id";
+    private static final String[] PARAM_QNs = {
+        "/Example/example_param1",
+        "/Example/example_param2",
+    };
+
+    private Mdb mdb;
+
+    @BeforeEach
+    public void setup() throws URISyntaxException, XtceLoadException,
+            XMLStreamException, IOException {
+
+        YConfiguration.setupTest(null);
+        mdb = MdbFactory
+                .createInstanceByConfig("indirect-param-ref");
+
+        TimeEncoding.setUp();
+    }
+
+    @Test
+    public void testProcessPacket() throws IOException {
+        XtceTmExtractor extractor = new XtceTmExtractor(mdb);
+        extractor.provideAll();
+
+        float[] paramValues = {1.23F, 4.56F};
+        long now = TimeEncoding.getWallclockTime();
+
+        for (int i = 0; i < 2; i++) {
+            byte[] packet = createPacket(i + 1, paramValues[i]);
+            ParameterValueList result = 
+                extractor.processPacket(packet, now, now, 0).getParameterResult();
+
+            assertEquals(2, result.getSize());
+            assertEquals(i + 1, result.get(mdb.getParameter(ID_QN), 0).getEngValue().toLong());
+            assertEquals(paramValues[i], 
+                result.get(mdb.getParameter(PARAM_QNs[i]), 0).getEngValue().toDouble());
+
+        }
+    }
+
+    private byte[] createPacket(int id, float value) throws IOException {
+        ByteArrayOutputStream arrayStream = new ByteArrayOutputStream();
+        DataOutputStream out = new DataOutputStream(arrayStream);
+
+        out.writeInt(id);
+        out.writeFloat(value);
+
+        return arrayStream.toByteArray();
+    }
+}

--- a/yamcs-core/src/test/resources/mdb.yaml
+++ b/yamcs-core/src/test/resources/mdb.yaml
@@ -100,4 +100,8 @@ xtce-refsolver:
           file: "src/test/resources/xtce/refsolver3.xml"
           
                  
+indirect-param-ref:
+    - type: xtce
+      args:
+          file: "../yamcs-xtce/src/test/resources/indirect-param.xml"
           

--- a/yamcs-xtce/src/main/java/org/yamcs/xtce/xml/Constants.java
+++ b/yamcs-xtce/src/main/java/org/yamcs/xtce/xml/Constants.java
@@ -7,6 +7,8 @@ public final class Constants {
     public static final String ATTR_INITIAL_VALUE = "initialValue";
     public static final String ATTR_SIZE_IN_BITS = "sizeInBits";
     public static final String ATTR_ENCODING = "encoding";
+    public static final String ATTR_ALIAS_NAME_SPACE = "aliasNameSpace";
+    
 
     public static final String ELEM_RELATIVE_TIME_PARAMETER_TYPE = "RelativeTimeParameterType";
     public static final String ELEM_ARRAY_PARAMETER_TYPE = "ArrayParameterType";
@@ -97,6 +99,7 @@ public final class Constants {
     public static final String ELEM_TERM = "Term";
     public static final String ELEM_SPLINE_POINT = "SplinePoint";
     public static final String ELEM_COUNT = "Count";
+    public static final String ELEM_PARAMETER_INSTANCE = "ParameterInstance";
     public static final String ELEM_PARAMETER_INSTANCE_REF = "ParameterInstanceRef";
     public static final String ELEM_ARGUMENT_INSTANCE_REF = "ArgumentInstanceRef";
     public static final String ELEM_STATIC_ALARM_RANGES = "StaticAlarmRanges";

--- a/yamcs-xtce/src/main/java/org/yamcs/xtce/xml/XtceStaxReader.java
+++ b/yamcs-xtce/src/main/java/org/yamcs/xtce/xml/XtceStaxReader.java
@@ -2531,7 +2531,7 @@ public class XtceStaxReader extends AbstractStaxReader {
             } else if (isStartElementWithName(ELEM_STREAM_SEGMENT_ENTRY)) {
                 skipXtceSection(ELEM_STREAM_SEGMENT_ENTRY);
             } else if (isStartElementWithName(ELEM_INDIRECT_PARAMETER_REF_ENTRY)) {
-                skipXtceSection(ELEM_INDIRECT_PARAMETER_REF_ENTRY);
+                entry = readIndirectParameterRefEntry(spaceSystem);
             } else if (isStartElementWithName(ELEM_ARRAY_PARAMETER_REF_ENTRY)) {
                 entry = readArrayParameterRefEntry(spaceSystem);
             } else if (isStartElementWithName(ELEM_ARGUMENT_REF_ENTRY)) {
@@ -2550,6 +2550,34 @@ public class XtceStaxReader extends AbstractStaxReader {
             }
         }
 
+    }
+
+    private SequenceEntry readIndirectParameterRefEntry(SpaceSystem spaceSystem) throws XMLStreamException {
+        log.trace(ELEM_INDIRECT_PARAMETER_REF_ENTRY);
+        checkStartElementPreconditions();
+
+        String aliasNameSpace = readAttribute(ATTR_ALIAS_NAME_SPACE, xmlEvent.asStartElement(), null);
+
+        IndirectParameterRefEntry indirectParameterRefEntry = new IndirectParameterRefEntry(0, null, null, aliasNameSpace);
+        indirectParameterRefEntry.setLocation(SequenceEntry.ReferenceLocationType.PREVIOUS_ENTRY, 0); // default
+
+        while (true) {
+            xmlEvent = xmlEventReader.nextEvent();
+
+            if (isStartElementWithName(ELEM_LOCATION_IN_CONTAINER_IN_BITS)) {
+                readLocationInContainerInBits(indirectParameterRefEntry);
+            } else if (isStartElementWithName(ELEM_PARAMETER_INSTANCE)) {
+                ParameterInstanceRef ref = readParameterInstanceRef(spaceSystem, null);
+                indirectParameterRefEntry.setParameterRef(ref);
+            } else if (isEndElementWithName(ELEM_INDIRECT_PARAMETER_REF_ENTRY)) {
+                if (indirectParameterRefEntry.getParameterRef() == null) {
+                    throw new XMLStreamException(ELEM_PARAMETER_INSTANCE + " not specified");
+                }
+                return indirectParameterRefEntry;
+            } else {
+                logUnknown();
+            }
+        }
     }
 
     private SequenceEntry readArrayParameterRefEntry(SpaceSystem spaceSystem) throws XMLStreamException {

--- a/yamcs-xtce/src/test/java/org/yamcs/xtce/IndirectParameterRefTest.java
+++ b/yamcs-xtce/src/test/java/org/yamcs/xtce/IndirectParameterRefTest.java
@@ -1,0 +1,40 @@
+package org.yamcs.xtce;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import javax.xml.stream.XMLStreamException;
+
+import org.junit.jupiter.api.Test;
+import org.yamcs.xtce.xml.XtceStaxReader;
+
+public class IndirectParameterRefTest {
+    @Test
+    public void testIndirectParameterRef() throws Exception {
+        try (var reader = new XtceStaxReader("src/test/resources/indirect-param.xml")) {
+            var ss = reader.readXmlDocument();
+            var idValuePair = ss.getSequenceContainer("id_value_pair");
+            assertNotNull(idValuePair);
+            assertEquals(2, idValuePair.entryList.size());
+ 
+            var idEntry = (ParameterEntry) idValuePair.entryList.get(0);
+            assertEquals("id", idEntry.getParameter().name);
+
+            var indirectEntry = (IndirectParameterRefEntry) idValuePair.entryList.get(1);
+            assertNotNull(indirectEntry.getReferenceLocation());
+            var ref = indirectEntry.getParameterRef();
+            assertNotNull(ref);
+            assertEquals("id", ref.getParameter().name);
+        }
+    }
+
+    @Test
+    public void testIndirectParameterRefBadXml() throws Exception {
+        try (var reader = new XtceStaxReader("src/test/resources/ipre-no-instance.xml")) {
+            assertThrows(XMLStreamException.class, () -> {
+                reader.readXmlDocument();
+            });
+        }
+    }
+}

--- a/yamcs-xtce/src/test/resources/indirect-param.xml
+++ b/yamcs-xtce/src/test/resources/indirect-param.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SpaceSystem name="Example"
+  xmlns="https://www.omg.org/spec/XTCE/20180204/SpaceSystem.xsd"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  shortDescription="Example XTCE to test IndirectParamRefs with aliases">
+
+  <TelemetryMetaData>
+    <ParameterTypeSet>
+      <IntegerParameterType name="id_type">
+        <IntegerDataEncoding sizeInBits="32" />
+      </IntegerParameterType>
+      <FloatParameterType name="float_type">
+        <FloatDataEncoding sizeInBits="32" />
+      </FloatParameterType>
+    </ParameterTypeSet>
+    <ParameterSet>
+      <Parameter parameterTypeRef="id_type" name="id" />
+      <Parameter parameterTypeRef="float_type" name="example_param1">
+        <AliasSet>
+          <Alias nameSpace="test-ns-id" alias="1" />
+        </AliasSet>
+      </Parameter>
+      <Parameter parameterTypeRef="float_type" name="example_param2">
+        <AliasSet>
+          <Alias nameSpace="test-ns-id" alias="2" />
+        </AliasSet>
+      </Parameter>
+    </ParameterSet>
+    <ContainerSet>
+      <SequenceContainer name="id_value_pair">
+        <EntryList>
+          <ParameterRefEntry parameterRef="id" />
+          <IndirectParameterRefEntry aliasNameSpace="test-ns-id">
+            <ParameterInstance parameterRef="id" />
+          </IndirectParameterRefEntry>
+        </EntryList>
+      </SequenceContainer>
+    </ContainerSet>
+  </TelemetryMetaData>
+
+</SpaceSystem>

--- a/yamcs-xtce/src/test/resources/ipre-no-instance.xml
+++ b/yamcs-xtce/src/test/resources/ipre-no-instance.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SpaceSystem name="Example"
+  xmlns="https://www.omg.org/spec/XTCE/20180204/SpaceSystem.xsd"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  shortDescription="Example XTCE to test IndirectParamRefs with aliases">
+
+  <TelemetryMetaData>
+    <ParameterTypeSet>
+      <IntegerParameterType name="id_type">
+        <IntegerDataEncoding sizeInBits="32" />
+      </IntegerParameterType>
+      <FloatParameterType name="float_type">
+        <FloatDataEncoding sizeInBits="32" />
+      </FloatParameterType>
+    </ParameterTypeSet>
+    <ParameterSet>
+      <Parameter parameterTypeRef="id_type" name="id" />
+      <Parameter parameterTypeRef="float_type" name="float" />
+    </ParameterSet>
+    <ContainerSet>
+      <SequenceContainer name="id_value_pair">
+        <EntryList>
+          <ParameterRefEntry parameterRef="id" />
+          <IndirectParameterRefEntry aliasNameSpace="/Example/non-existent-ns">
+            <!-- missing ParameterInstance -->
+          </IndirectParameterRefEntry>
+        </EntryList>
+      </SequenceContainer>
+    </ContainerSet>
+  </TelemetryMetaData>
+
+</SpaceSystem>


### PR DESCRIPTION
Needed for @xpromache's suggested approach of using IndirectParamRefEntry to implement "deduced" parameter value types as defined in PUS.

I'll sign the CLA shortly. 