### PR TITLE
Use the configured entityIdLength for ProxyPutRequest

### DIFF
--- a/yamcs-core/src/main/java/org/yamcs/cfdp/CfdpService.java
+++ b/yamcs-core/src/main/java/org/yamcs/cfdp/CfdpService.java
@@ -1032,8 +1032,9 @@ public class CfdpService extends AbstractFileTransferService implements StreamSu
         booleanOptions.putAll(optionValues.booleanOptions);
 
         // Prepare request
+        int entityIdLength = config.getInt("entityIdLength");
         ArrayList<MessageToUser> messagesToUser = new ArrayList<>(
-                List.of(new ProxyPutRequest(destinationId, sourcePath, objectName)));
+                List.of(new ProxyPutRequest(destinationId, sourcePath, objectName, entityIdLength)));
 
         CfdpPacket.TransmissionMode transmissionMode = CfdpPacket.TransmissionMode.UNACKNOWLEDGED;
         if (Boolean.TRUE.equals(booleanOptions.get(RELIABLE_OPTION))) {

--- a/yamcs-core/src/main/java/org/yamcs/cfdp/pdu/ProxyPutRequest.java
+++ b/yamcs-core/src/main/java/org/yamcs/cfdp/pdu/ProxyPutRequest.java
@@ -6,15 +6,15 @@ import org.yamcs.utils.StringConverter;
 
 import java.nio.ByteBuffer;
 
-import static org.yamcs.cfdp.CfdpUtils.longToTrimmedBytes;
+import static org.yamcs.cfdp.CfdpUtils.longToBytesFixed;
 
 public class ProxyPutRequest extends ReservedMessageToUser {
     private final long destinationEntityId;
     private final String sourceFileName;
     private final String destinationFileName;
 
-    public ProxyPutRequest(long destinationEntityId, String sourceFileName, String destinationFileName) {
-        super(MessageType.PROXY_PUT_REQUEST, encode(destinationEntityId, sourceFileName, destinationFileName));
+    public ProxyPutRequest(long destinationEntityId, String sourceFileName, String destinationFileName, int entityIdLength) {
+        super(MessageType.PROXY_PUT_REQUEST, encode(destinationEntityId, sourceFileName, destinationFileName, entityIdLength));
         this.destinationEntityId = destinationEntityId;
         this.sourceFileName = sourceFileName;
         this.destinationFileName = destinationFileName;
@@ -29,9 +29,9 @@ public class ProxyPutRequest extends ReservedMessageToUser {
         this.destinationFileName = new String(LV.readLV(buffer).getValue());
     }
 
-    private static byte[] encode(long destinationEntityId, String sourceFileName, String destinationFileName) {
+    private static byte[] encode(long destinationEntityId, String sourceFileName, String destinationFileName, int entityIdLength) {
         return Bytes.concat(
-            new LV(longToTrimmedBytes(destinationEntityId)).getBytes(),
+            new LV(longToBytesFixed(destinationEntityId, entityIdLength)).getBytes(),
             new LV(sourceFileName).getBytes(),
             new LV(destinationFileName).getBytes()
         );


### PR DESCRIPTION
When requesting a file from a remote entity, a ProxyPutRequest is sent. 
Previously, the destination entity ID was trimmed to the smallest entity ID buffer size that fits. 
When the destination entity ID is small (1), it only uses one byte.
This confused the CFDP server I'm working on, since it expected the size of that field to be fixed (to the default of 2 bytes). 

I'm not sure if expecting that to be fixed for a given server config is reasonable or not, so feel free to close this PR if it's working as intended, and I'll change my server.