### PR TITLE
Interpret USLP version number as a byte instead of int

### DIFF
--- a/yamcs-core/src/main/java/org/yamcs/tctm/ccsds/UslpFrameDecoder.java
+++ b/yamcs-core/src/main/java/org/yamcs/tctm/ccsds/UslpFrameDecoder.java
@@ -35,7 +35,7 @@ public class UslpFrameDecoder implements TransferFrameDecoder {
     public DownlinkTransferFrame decode(byte[] data, int offset, int length) throws TcTmException {
         log.trace("decoding frame buf length: {}, dataOffset: {} , dataLength: {}", data.length, offset, length);
 
-        int version = data[offset] >>4;
+        int version = (data[offset] & 0xFF) >> 4;
         if(version != 12) {
             throw new TcTmException("Bad frame version number " + version + "; expected 12 (USLP)");
         }


### PR DESCRIPTION
Otherwise, 192 (12 << 4) gets interpreted as -4 and USLP frames are not decoded.

I'm not sure if my proposed fix is the right way to go about it. I'm still kind of confused about the fact that `byte` is a signed integer in Java.

Also let me know if you'd like a test for this.
