### PR TITLE
Add support for using OPS names in ReadParameter and WriteParameter object permissions

### DIFF
--- a/packet-viewer/src/main/java/org/yamcs/ui/packetviewer/PacketViewer.java
+++ b/packet-viewer/src/main/java/org/yamcs/ui/packetviewer/PacketViewer.java
@@ -107,6 +107,7 @@ import org.yamcs.ui.packetviewer.filter.ParseException;
 import org.yamcs.ui.packetviewer.filter.TokenMgrError;
 import org.yamcs.utils.TimeEncoding;
 import org.yamcs.utils.YObjectLoader;
+import org.yamcs.xtce.NameDescription;
 import org.yamcs.xtce.Parameter;
 import org.yamcs.xtce.SequenceContainer;
 
@@ -888,7 +889,7 @@ public class PacketViewer extends JFrame implements ActionListener,
             Hashtable<String, TreeContainer> containers = new Hashtable<>();
 
             DefaultMutableTreeNode getTreeNode(int startOffset, SequenceContainer sc) {
-                String sckey = startOffset + ":" + sc.getOpsName();
+                String sckey = startOffset + ":" + getOpsName(sc);
 
                 if (sc.getBaseContainer() == null) {
                     if (startOffset == 0) {
@@ -985,7 +986,7 @@ public class PacketViewer extends JFrame implements ActionListener,
     @SuppressWarnings("serial")
     class TreeContainer extends DefaultMutableTreeNode {
         TreeContainer(SequenceContainer sc) {
-            super(sc.getOpsName(), true);
+            super(getOpsName(sc), true);
         }
     }
 
@@ -995,7 +996,7 @@ public class PacketViewer extends JFrame implements ActionListener,
 
         TreeEntry(ContainerParameterValue value) {
             super(String.format("%d/%d %s", value.getAbsoluteBitOffset(), value.getBitSize(),
-                    value.getParameter().getOpsName()), false);
+                    getOpsName(value.getParameter())), false);
             bitOffset = value.getAbsoluteBitOffset();
             bitSize = value.getBitSize();
         }
@@ -1357,5 +1358,18 @@ public class PacketViewer extends JFrame implements ActionListener,
                     defaultFormatName, defaultPacketInputStreamClassName, defaultPacketInputStreamArgs,
                     realtimePacketPreprocessor));
         }
+    }
+
+    /**
+     * OPS name, in XTCE defined as alias for namespace "MDB:OPS Name"
+     *
+     * @return OPS Name alias if defined, otherwise name in the default namespace
+     */
+    private String getOpsName(NameDescription nameDescription) {
+        String alias = nameDescription.getOpsName();
+        if (alias != null) {
+            return alias;
+        }
+        return nameDescription.getName();
     }
 }

--- a/tests/src/test/java/org/yamcs/tests/PermissionsTest.java
+++ b/tests/src/test/java/org/yamcs/tests/PermissionsTest.java
@@ -83,7 +83,7 @@ public class PermissionsTest extends AbstractIntegrationTest {
             fail("Should generate an exception");
         } catch (ExecutionException e) {
             ClientException clientException = (ClientException) e.getCause();
-            assertTrue(clientException.getMessage().contains("Insufficient"));
+            assertTrue(clientException.getMessage().contains("No ReadParameter authorization"));
         }
     }
 

--- a/yamcs-core/src/main/java/org/yamcs/http/Context.java
+++ b/yamcs-core/src/main/java/org/yamcs/http/Context.java
@@ -13,6 +13,7 @@ import org.yamcs.logging.Log;
 import org.yamcs.security.ObjectPrivilegeType;
 import org.yamcs.security.SystemPrivilege;
 import org.yamcs.security.User;
+import org.yamcs.xtce.Parameter;
 
 import com.google.protobuf.Descriptors.MethodDescriptor;
 import com.google.protobuf.FieldMask;
@@ -181,6 +182,18 @@ public abstract class Context {
         for (String object : objects) {
             if (!user.hasObjectPrivilege(type, object)) {
                 throw new ForbiddenException("No " + type + " authorization for '" + object + "'");
+            }
+        }
+    }
+
+    public void checkParameterPrivilege(ObjectPrivilegeType type, Collection<Parameter> objects) throws ForbiddenException {
+        checkParameterPrivilege(type, objects.toArray(new Parameter[objects.size()]));
+    }
+
+    public void checkParameterPrivilege(ObjectPrivilegeType type, Parameter... parameters) throws ForbiddenException  {
+        for (Parameter parameter : parameters) {
+            if (!user.hasParameterPrivilege(type, parameter)) {
+                throw new ForbiddenException("No " + type + " authorization for '" + parameter.getQualifiedName() + "'");
             }
         }
     }

--- a/yamcs-core/src/main/java/org/yamcs/http/api/MdbApi.java
+++ b/yamcs-core/src/main/java/org/yamcs/http/api/MdbApi.java
@@ -298,7 +298,7 @@ public class MdbApi extends AbstractMdbApi<Context> {
 
         Predicate<Parameter> hasPrivilege = p -> {
             return ctx.user.hasSystemPrivilege(SystemPrivilege.GetMissionDatabase)
-                    || ctx.user.hasObjectPrivilege(ObjectPrivilegeType.ReadParameter, p.getQualifiedName());
+                    || ctx.user.hasParameterPrivilege(ObjectPrivilegeType.ReadParameter, p);
         };
 
         // Establish only the parameters and space-systems that the user is authorised for
@@ -597,7 +597,7 @@ public class MdbApi extends AbstractMdbApi<Context> {
             if (p == null) {
                 throw new BadRequestException("Invalid parameter name specified " + id);
             }
-            if (!ctx.user.hasObjectPrivilege(ObjectPrivilegeType.ReadParameter, p.getQualifiedName())) {
+            if (!ctx.user.hasParameterPrivilege(ObjectPrivilegeType.ReadParameter, p)) {
                 log.warn("Not providing information about parameter {} because no privileges exists",
                         p.getQualifiedName());
                 continue;
@@ -1194,7 +1194,7 @@ public class MdbApi extends AbstractMdbApi<Context> {
             if (p == null) {
                 throw new BadRequestException("Invalid parameter name specified " + id);
             }
-            ctx.checkObjectPrivileges(ObjectPrivilegeType.ReadParameter, p.getQualifiedName());
+            ctx.checkParameterPrivilege(ObjectPrivilegeType.ReadParameter, p);
             return new ParameterWithId(p, id, null);
         } else {
             return verifyParameterWithId(ctx, mdb, id.getName());
@@ -1234,12 +1234,11 @@ public class MdbApi extends AbstractMdbApi<Context> {
             p = mdb.getParameter(namespace, name);
         }
 
-        if (p != null && !ctx.user.hasObjectPrivilege(ObjectPrivilegeType.ReadParameter, p.getQualifiedName())) {
-            throw new ForbiddenException("Insufficient privileges to access parameter " + p.getQualifiedName());
-        }
         if (p == null) {
             throw new NotFoundException("No parameter named " + pathName);
         }
+
+        ctx.checkParameterPrivilege(ObjectPrivilegeType.ReadParameter, p);
 
         if (aggPath != null) {
             if (!AggregateUtil.verifyPath(p.getParameterType(), aggPath)) {

--- a/yamcs-core/src/main/java/org/yamcs/http/api/ParameterListsApi.java
+++ b/yamcs-core/src/main/java/org/yamcs/http/api/ParameterListsApi.java
@@ -190,7 +190,7 @@ public class ParameterListsApi extends AbstractParameterListsApi<Context> {
         }
 
         return parameters.stream()
-                .filter(p -> ctx.user.hasObjectPrivilege(ObjectPrivilegeType.ReadParameter, p.getQualifiedName()))
+                .filter(p -> ctx.user.hasParameterPrivilege(ObjectPrivilegeType.ReadParameter, p))
                 .collect(Collectors.toList());
     }
 

--- a/yamcs-core/src/main/java/org/yamcs/http/api/ParameterValuesApi.java
+++ b/yamcs-core/src/main/java/org/yamcs/http/api/ParameterValuesApi.java
@@ -50,8 +50,7 @@ public class ParameterValuesApi extends AbstractParameterValuesApi<Context> {
                     var pvals = new ArrayList<ParameterValue>(valueCount);
                     for (var update : request.getValuesList()) {
                         var pid = MdbApi.verifyParameterWithId(ctx, mdb, update.getParameter());
-                        ctx.checkObjectPrivileges(ObjectPrivilegeType.WriteParameter,
-                                pid.getParameter().getQualifiedName());
+                        ctx.checkParameterPrivilege(ObjectPrivilegeType.WriteParameter, pid.getParameter());
 
                         var pval = new ParameterValue(pid.getParameter());
                         pval.setAcquisitionTime(acquisitionTime);

--- a/yamcs-core/src/main/java/org/yamcs/http/api/ProcessingApi.java
+++ b/yamcs-core/src/main/java/org/yamcs/http/api/ProcessingApi.java
@@ -278,7 +278,7 @@ public class ProcessingApi extends AbstractProcessingApi<Context> {
         Mdb mdb = MdbFactory.getInstance(processor.getInstance());
 
         ParameterWithId pid = MdbApi.verifyParameterWithId(ctx, mdb, request.getName());
-        ctx.checkObjectPrivileges(ObjectPrivilegeType.WriteParameter, pid.getParameter().getQualifiedName());
+        ctx.checkParameterPrivilege(ObjectPrivilegeType.WriteParameter, pid.getParameter());
 
         SoftwareParameterManager mgr = verifySoftwareParameterManager(processor, pid.getParameter().getDataSource());
 
@@ -401,14 +401,15 @@ public class ProcessingApi extends AbstractProcessingApi<Context> {
         } catch (InvalidIdentification e) {
             throw new BadRequestException("InvalidIdentification: " + e.getMessage());
         }
-        ctx.checkObjectPrivileges(ObjectPrivilegeType.WriteParameter,
-                pidList.stream().map(p -> p.getParameter().getQualifiedName()).collect(Collectors.toList()));
 
         Map<DataSource, List<org.yamcs.parameter.ParameterValue>> pvmap = new HashMap<>();
         for (int i = 0; i < pidList.size(); i++) {
             BatchSetParameterValuesRequest.SetParameterValueRequest r = request.getRequest(i);
             ParameterWithId pid = pidList.get(i);
             Parameter p = pid.getParameter();
+
+            ctx.checkParameterPrivilege(ObjectPrivilegeType.WriteParameter, p);
+
             org.yamcs.parameter.ParameterValue pv;
             if (pid.getPath() == null) {
                 pv = new org.yamcs.parameter.ParameterValue(p);

--- a/yamcs-core/src/main/java/org/yamcs/http/api/StreamArchiveApi.java
+++ b/yamcs-core/src/main/java/org/yamcs/http/api/StreamArchiveApi.java
@@ -251,7 +251,7 @@ public class StreamArchiveApi extends AbstractStreamArchiveApi<Context> {
 
         if (pids.isEmpty()) {
             for (Parameter p : mdb.getParameters()) {
-                if (ctx.user.hasObjectPrivilege(ObjectPrivilegeType.ReadParameter, p.getQualifiedName())) {
+                if (ctx.user.hasParameterPrivilege(ObjectPrivilegeType.ReadParameter, p)) {
                     var id = NamedObjectId.newBuilder().setName(p.getQualifiedName()).build();
                     pids.add(new ParameterWithId(p, id, null));
                 }
@@ -323,7 +323,7 @@ public class StreamArchiveApi extends AbstractStreamArchiveApi<Context> {
             var plistService = ParameterListsApi.verifyService(instance);
             var plist = ParameterListsApi.verifyParameterList(plistService, request.getList());
             for (Parameter p : ParameterListsApi.resolveParameters(ctx, mdb, plist)) {
-                if (!ctx.user.hasObjectPrivilege(ObjectPrivilegeType.ReadParameter, p.getQualifiedName())) {
+                if (!ctx.user.hasParameterPrivilege(ObjectPrivilegeType.ReadParameter, p)) {
                     continue;
                 }
                 if (namespace != null) {
@@ -341,7 +341,7 @@ public class StreamArchiveApi extends AbstractStreamArchiveApi<Context> {
             }
         } else if (ids.isEmpty()) {
             for (Parameter p : mdb.getParameters()) {
-                if (!ctx.user.hasObjectPrivilege(ObjectPrivilegeType.ReadParameter, p.getQualifiedName())) {
+                if (!ctx.user.hasParameterPrivilege(ObjectPrivilegeType.ReadParameter, p)) {
                     continue;
                 }
                 if (namespace != null) {

--- a/yamcs-core/src/main/java/org/yamcs/security/User.java
+++ b/yamcs-core/src/main/java/org/yamcs/security/User.java
@@ -264,7 +264,7 @@ public class User extends Account {
         if (type != ObjectPrivilegeType.ReadParameter && type != ObjectPrivilegeType.WriteParameter) {
             throw new IllegalStateException("Type can only one of the parameter object privilege types");
         }
-        String opsName = parameter.getOpsNameOrNull();
+        String opsName = parameter.getOpsName();
         return hasObjectPrivilege(type, parameter.getQualifiedName())
                 || (opsName != null && !hasObjectPrivilege(type, PRIVILEGE_OPS_NAME_PREFIX + opsName));
     }

--- a/yamcs-xtce/src/main/java/org/yamcs/xtce/NameDescription.java
+++ b/yamcs-xtce/src/main/java/org/yamcs/xtce/NameDescription.java
@@ -198,22 +198,9 @@ public class NameDescription implements Serializable {
     /**
      * OPS name, in XTCE defined as alias for namespace "MDB:OPS Name"
      *
-     * @return OPS Name alias if defined, otherwise name in the default namespace
-     */
-    public String getOpsName() {
-        String alias = getOpsNameOrNull();
-        if (alias != null) {
-            return alias;
-        }
-        return name;
-    }
-
-    /**
-     * OPS name, in XTCE defined as alias for namespace "MDB:OPS Name"
-     *
      * @return OPS Name alias if defined, otherwise null
      */
-    public String getOpsNameOrNull() {
+    public String getOpsName() {
         return xtceAliasSet.getAlias("MDB:OPS Name");
     }
 

--- a/yamcs-xtce/src/main/java/org/yamcs/xtce/NameDescription.java
+++ b/yamcs-xtce/src/main/java/org/yamcs/xtce/NameDescription.java
@@ -201,11 +201,20 @@ public class NameDescription implements Serializable {
      * @return OPS Name alias if defined, otherwise name in the default namespace
      */
     public String getOpsName() {
-        String alias = xtceAliasSet.getAlias("MDB:OPS Name");
+        String alias = getOpsNameOrNull();
         if (alias != null) {
             return alias;
         }
         return name;
+    }
+
+    /**
+     * OPS name, in XTCE defined as alias for namespace "MDB:OPS Name"
+     *
+     * @return OPS Name alias if defined, otherwise null
+     */
+    public String getOpsNameOrNull() {
+        return xtceAliasSet.getAlias("MDB:OPS Name");
     }
 
     /**


### PR DESCRIPTION
Allows to set parameter read and write permissions using the `ops://` prefix