### PR TITLE
fix: Ensure correct arguments are passed in the function call

### DIFF
--- a/yamcs-core/src/test/java/org/yamcs/mdb/ArrayInArrayArgTest.java
+++ b/yamcs-core/src/test/java/org/yamcs/mdb/ArrayInArrayArgTest.java
@@ -53,37 +53,37 @@ public class ArrayInArrayArgTest {
         args.put("outer_array", Arrays.asList(a1, a2));
 
         // test with all array lengths set
-        byte[] b = metaCommandProcessor.buildCommand(mc, args).getCmdPacket();
+        byte[] b = metaCommandProcessor.buildCommand(mc, args, 0).getCmdPacket();
         assertEquals("00020200AB00CD010088", StringConverter.arrayToHexString(b));
 
         // test with the a2 length not set
         a2.remove("inner_array_length");
-        b = metaCommandProcessor.buildCommand(mc, args).getCmdPacket();
+        b = metaCommandProcessor.buildCommand(mc, args, 0).getCmdPacket();
         assertEquals("00020200AB00CD010088", StringConverter.arrayToHexString(b));
 
         // test with the a2 length set to the wrong value
         a2.put("inner_array_length", 5);
         assertThrows(ErrorInCommand.class, () -> {
-            metaCommandProcessor.buildCommand(mc, args);
+            metaCommandProcessor.buildCommand(mc, args, 0);
         });
 
         // test with the a2 length set to the wrong type
         a2.put("inner_array_length", "s");
         assertThrows(ErrorInCommand.class, () -> {
-            metaCommandProcessor.buildCommand(mc, args);
+            metaCommandProcessor.buildCommand(mc, args, 0);
         });
 
         // test with no length set
         a2.remove("inner_array_length");
         a1.remove("inner_array_length");
         args.remove("outer_array_length");
-        b = metaCommandProcessor.buildCommand(mc, args).getCmdPacket();
+        b = metaCommandProcessor.buildCommand(mc, args, 0).getCmdPacket();
         assertEquals("00020200AB00CD010088", StringConverter.arrayToHexString(b));
 
         // test with outer length set to the wrong value
         args.put("outer_array_length", 20);
         assertThrows(ErrorInCommand.class, () -> {
-            metaCommandProcessor.buildCommand(mc, args);
+            metaCommandProcessor.buildCommand(mc, args, 0);
         });
     }
 


### PR DESCRIPTION
<!--
Thank you for opening a Pull Request! Before submitting anything
non-trivial (more than a few lines), there are a few things you can
do to make sure it goes smoothly:

* Please start a discussion, before writing your code! That way we
  can discuss the change, evaluate designs, and agree on the general
  idea.

* You will need to sign a Contributor License Agreement (CLA):
  https://yamcs.org/static/Yamcs_Contributor_Agreement_v2.0.pdf

  You remain owner of your contribution, but in addition you give
  "Space Applications Services" the legal permission to use and
  distribute your contribution. This ensures that we can continue
  providing alternative licensing as a commercial feature.

Thanks again!
-->

I am reporting a fix for a bug in one of the test files. The `missionTime` argument for the function call was missing, which has now been added.

The fix allows yamcs to be built via the `Makefile`.

Thanks
