### PR TITLE
#1041 fix getBinaryLength when pus11 set

### DIFF
--- a/yamcs-core/src/main/java/org/yamcs/pus/PusCommandPostprocessor.java
+++ b/yamcs-core/src/main/java/org/yamcs/pus/PusCommandPostprocessor.java
@@ -191,12 +191,17 @@ public class PusCommandPostprocessor extends AbstractCommandPostProcessor {
 
     @Override
     public int getBinaryLength(PreparedCommand pc) {
-        byte[] binary = pc.getBinary();
+        int binaryLength = binary.length;
         if (hasCrc(pc)) {
-            return binary.length + 2;
-        } else {
-            return binary.length;
+            binaryLength += 2;
         }
+        if (pc.getAttribute("pus11ScheduleAt") != null) {
+            binaryLength += 13 + timeEncoder.getEncodedLength();
+            if (pus11Crc) {
+                binaryLength += 2;
+            }
+        }
+        return binaryLength;
     }
 
     private boolean hasCrc(PreparedCommand pc) {


### PR DESCRIPTION
This PR shall fix #1041

The getBinaryLength() method does not take the additional length of the command into account. This is a quick fix until the function is rewritten in a ordered manner as suggested in the issue. Feel free to comment or improve! I am not that deep into the topic, its just what I found in a very limited time with the codebase.

The PR descriptionen stated that I need to fill out a .pdf for the contribution. Where can I submit that? Your help is much appreciated :)