### PR TITLE
Mark some members of UdpTcFrameLink and UdpTmFrameLink as protected

### DIFF
--- a/yamcs-core/src/main/java/org/yamcs/tctm/ccsds/UdpTcFrameLink.java
+++ b/yamcs-core/src/main/java/org/yamcs/tctm/ccsds/UdpTcFrameLink.java
@@ -29,11 +29,11 @@ import com.google.common.util.concurrent.RateLimiter;
  */
 public class UdpTcFrameLink extends AbstractTcFrameLink implements Runnable {
     String host;
-    int port;
-    DatagramSocket socket;
-    InetAddress address;
+    protected int port;
+    protected DatagramSocket socket;
+    protected InetAddress address;
     Thread thread;
-    RateLimiter rateLimiter;
+    protected RateLimiter rateLimiter;
 
     @Override
     public Spec getSpec() {

--- a/yamcs-core/src/main/java/org/yamcs/tctm/ccsds/UdpTmFrameLink.java
+++ b/yamcs-core/src/main/java/org/yamcs/tctm/ccsds/UdpTmFrameLink.java
@@ -22,14 +22,14 @@ import org.yamcs.utils.StringConverter;
  *
  */
 public class UdpTmFrameLink extends AbstractTmFrameLink implements Runnable {
-    private DatagramSocket tmSocket;
+    protected DatagramSocket tmSocket;
     private int port;
 
     /**
      * Bytes to ignore at the start of the frame
      */
     protected int initialBytesToStrip;
-    DatagramPacket datagram;
+    protected DatagramPacket datagram;
 
     @Override
     public Spec getSpec() {


### PR DESCRIPTION
This facilitates implementing custom UDP frame links through inheritance.


<!--
Thank you for opening a Pull Request! Before submitting anything
non-trivial (more than a few lines), there are a few things you can
do to make sure it goes smoothly:

* Please start a discussion, before writing your code! That way we
  can discuss the change, evaluate designs, and agree on the general
  idea.

* You will need to sign a Contributor License Agreement (CLA):
  https://yamcs.org/static/Yamcs_Contributor_Agreement_v2.0.pdf

  You remain owner of your contribution, but in addition you give
  "Space Applications Services" the legal permission to use and
  distribute your contribution. This ensures that we can continue
  providing alternative licensing as a commercial feature.

Thanks again!
-->

