### PR TITLE
Show INVALID acquisition status in ya-expirable

### DIFF
--- a/yamcs-web/src/main/webapp/projects/webapp-sdk/src/lib/components/expirable/expirable.component.html
+++ b/yamcs-web/src/main/webapp/projects/webapp-sdk/src/lib/components/expirable/expirable.component.html
@@ -4,4 +4,10 @@
     &nbsp;
     <mat-icon [matTooltip]="getExpiredTooltip()" matTooltipClass="multiline">access_time</mat-icon>
   }
+  @if (invalid) {
+    &nbsp;
+    <mat-icon [matTooltip]="getInvalidTooltip()" matTooltipClass="multiline" color="warn">
+      error
+    </mat-icon>
+  }
 </span>

--- a/yamcs-web/src/main/webapp/projects/webapp-sdk/src/lib/components/expirable/expirable.component.ts
+++ b/yamcs-web/src/main/webapp/projects/webapp-sdk/src/lib/components/expirable/expirable.component.ts
@@ -18,6 +18,10 @@ export class YaExpirable {
     return this.pval && this.pval.acquisitionStatus === 'EXPIRED';
   }
 
+  get invalid() {
+    return this.pval && this.pval.acquisitionStatus === 'INVALID';
+  }
+
   getExpiredTooltip() {
     if (this.pval) {
       let msg = 'EXPIRED VALUE.\n';
@@ -27,5 +31,10 @@ export class YaExpirable {
     } else {
       return 'EXPIRED VALUE';
     }
+  }
+
+  getInvalidTooltip() {
+    // TODO: provide valid range?
+    return 'INVALID VALUE';
   }
 }


### PR DESCRIPTION
<img width="464" height="85" alt="image" src="https://github.com/user-attachments/assets/e4c8a0d3-0c13-4f3c-889c-1cfa14fc5c29" />
<img width="367" height="191" alt="image" src="https://github.com/user-attachments/assets/2030079e-d204-4c29-9ae1-d9ac705a1509" />

I added the indicator to `ya-expirable` so that it's automatically shown everywhere the expired icon is shown. But I suppose the name is now a bit misleading :sweat_smile: 

Closes #1060.