### PR TITLE
Support length argument for substring sql function

### DIFF
--- a/yamcs-core/src/main/java/org/yamcs/yarch/streamsql/funct/SubstringExpression.java
+++ b/yamcs-core/src/main/java/org/yamcs/yarch/streamsql/funct/SubstringExpression.java
@@ -26,12 +26,19 @@ public class SubstringExpression extends Expression {
         children[0].fillCode_getValueReturn(code);
         code.append(",");
         children[1].fillCode_getValueReturn(code);
-        
+        if (children.length==3) {
+            code.append(",");
+            children[2].fillCode_getValueReturn(code);
+        }
         code.append(")");
     }
-    
+
     static public byte[] substring(byte[] b, int offset) {
         return  Arrays.copyOfRange(b, offset, b.length);
     }
-    
+
+    static public byte[] substring(byte[] b, int offset, int length) {
+        return Arrays.copyOfRange(b, offset, offset+length);
+    }
+
 }

--- a/yamcs-core/src/test/java/org/yamcs/yarch/StreamSelectBinaryFunctionTest.java
+++ b/yamcs-core/src/test/java/org/yamcs/yarch/StreamSelectBinaryFunctionTest.java
@@ -11,13 +11,14 @@ import org.yamcs.utils.StringConverter;
 public class StreamSelectBinaryFunctionTest extends YarchTestCase {
 
     final int n = 10;
+    final int xLength = 300;
 
     public void createFeeder1() throws YarchException {
         Stream s;
         final TupleDefinition tpdef = new TupleDefinition();
         tpdef.addColumn("x", DataType.BINARY);
         tpdef.addColumn("y", DataType.INT);
-        byte[] x = new byte[300];
+        byte[] x = new byte[xLength];
         s = (new Stream(ydb, "stream_in", tpdef) {
             @Override
             public void doStart() {
@@ -40,12 +41,31 @@ public class StreamSelectBinaryFunctionTest extends YarchTestCase {
     public void testSubstring() throws Exception {
         createFeeder1();
 
-        execute("create stream stream_out1 as select substring(x, y) from stream_in");
+        execute("create stream stream_out1 as select substring(x, y), y from stream_in");
         List<Tuple> l = fetchAll("stream_out1");
         assertEquals(n, l.size());
         for (int i = 0; i < n; i++) {
             Tuple t = l.get(i);
             byte[] x = (byte[]) t.getColumn(0);
+            int y = (int) t.getColumn(1);
+            assertEquals(xLength-y, x.length);
+            assertEquals(i, ByteArrayUtils.decodeShort(x, 0));
+        }
+    }
+
+    @Test
+    public void testSubstring_withLength() throws Exception {
+        createFeeder1();
+
+        int substringLength = 2;
+
+        execute("create stream stream_out1 as select substring(x, y, " + substringLength + ") from stream_in");
+        List<Tuple> l = fetchAll("stream_out1");
+        assertEquals(n, l.size());
+        for (int i = 0; i < n; i++) {
+            Tuple t = l.get(i);
+            byte[] x = (byte[]) t.getColumn(0);
+            assertEquals(substringLength, x.length);
             assertEquals(i, ByteArrayUtils.decodeShort(x, 0));
         }
     }


### PR DESCRIPTION
I was looking at the documentation for the SQL functions and noticed that the substring function in the code did not support the length argument, contrary to the documentation.
Link: https://docs.yamcs.org/yamcs-server-manual/sql-language/functions/#substring

The message from the pull request textbox mentioned needing to sign a contributor's agreement before submitting "more than a few lines of code", let me know if I need to do so first or if, as was mentioned on the template suggestion, there is a need for discussion first.

Thank you