### PR TITLE
Fix SDLS header offset for USLP uplink

### DIFF
--- a/yamcs-core/src/main/java/org/yamcs/tctm/ccsds/UslpUplinkFrameFactory.java
+++ b/yamcs-core/src/main/java/org/yamcs/tctm/ccsds/UslpUplinkFrameFactory.java
@@ -94,11 +94,15 @@ public class UslpUplinkFrameFactory implements UplinkFrameFactory<UslpUplinkTran
         UslpUplinkTransferFrame frame = new UslpUplinkTransferFrame(data, uslpParams.spacecraftId,
                 vcParams.vcId, mapId, cmdControl);
         frame.genTime = generationTime;
+
+        // In this case, data start := first byte of TFDF *after* TFDF header
         frame.setDataStart(dataStart);
         frame.setDataEnd(dataStart + dataLength);
 
         if (isEncrypted) {
+            // Move data start forward to leave space for header
             frame.setDataStart(frame.getDataStart() + sdlsInfo.sa().getHeaderSize());
+            // Move data end forward to account for header
             frame.setDataEnd(frame.getDataEnd() + sdlsInfo.sa().getHeaderSize());
         }
 
@@ -148,8 +152,11 @@ public class UslpUplinkFrameFactory implements UplinkFrameFactory<UslpUplinkTran
 
         // Insert zone is left as zero (Java initialises byte arrays to 0)
 
+        // The start of the transfer frame data field (TFDF), points to the TFDF header
+        int tfdfStart = getTfdfStart(frame);
+
         // Data zone header
-        data[primaryHeaderSize + uslpParams.insertZoneLength] = ZONE_HEADER_BYTE;
+        data[tfdfStart] = ZONE_HEADER_BYTE;
 
         // SDLS encryption
         short spi = vcParams.encryptionSpi;
@@ -162,7 +169,7 @@ public class UslpUplinkFrameFactory implements UplinkFrameFactory<UslpUplinkTran
                     authMask = StandardAuthMask.USLP(primaryHeaderSize, uslpParams.insertZoneLength,
                             sa.securityHdrAuthMask());
                 }
-                sa.applySecurity(data, 0, getTfdfStart(frame) - sa.getHeaderSize(),
+                sa.applySecurity(data, 0, tfdfStart - sa.getHeaderSize(),
                         frame.getDataEnd() + sa.getTrailerSize(), authMask);
             } catch (GeneralSecurityException e) {
                 throw new RuntimeException(e);

--- a/yamcs-core/src/main/java/org/yamcs/tctm/ccsds/UslpUplinkFrameFactory.java
+++ b/yamcs-core/src/main/java/org/yamcs/tctm/ccsds/UslpUplinkFrameFactory.java
@@ -116,6 +116,10 @@ public class UslpUplinkFrameFactory implements UplinkFrameFactory<UslpUplinkTran
         return length;
     }
 
+    int getTfdfStart(UslpUplinkTransferFrame frame) {
+        return frame.getDataStart() - ZONE_HEADER_SIZE;
+    }
+
     @Override
     public byte[] encodeFrame(UslpUplinkTransferFrame frame) {
         byte[] data = frame.getData();
@@ -158,7 +162,7 @@ public class UslpUplinkFrameFactory implements UplinkFrameFactory<UslpUplinkTran
                     authMask = StandardAuthMask.USLP(primaryHeaderSize, uslpParams.insertZoneLength,
                             sa.securityHdrAuthMask());
                 }
-                sa.applySecurity(data, 0, frame.getDataStart() - sa.getHeaderSize(),
+                sa.applySecurity(data, 0, getTfdfStart(frame) - sa.getHeaderSize(),
                         frame.getDataEnd() + sa.getTrailerSize(), authMask);
             } catch (GeneralSecurityException e) {
                 throw new RuntimeException(e);


### PR DESCRIPTION
SDLS security header was off by one byte, so the USLP TFDF header was actually in front of the security header. This shouldn't be the case; the TFDF header is inside of the security header and trailer.