### PR TITLE
Fix operator precedence in TM secondary header length decoding

### DIFF
--- a/yamcs-core/src/main/java/org/yamcs/tctm/ccsds/TmFrameDecoder.java
+++ b/yamcs-core/src/main/java/org/yamcs/tctm/ccsds/TmFrameDecoder.java
@@ -83,7 +83,9 @@ public class TmFrameDecoder implements TransferFrameDecoder {
         boolean syncFlag = (tfdfs & 0x4000) == 0x4000;
 
         if (secHeaderPresent) {
-            int secHeaderLength = 1 + data[dataOffset] & 0x3F;
+            // CCSDS 132.0-B-3 4.1.3.2.3: low 6 bits of the first secondary header byte
+            // encode (length - 1); the top 2 bits are the secondary header version number
+            int secHeaderLength = 1 + (data[dataOffset] & 0x3F);
             ttf.setShStart(dataOffset);
             ttf.setShLength(secHeaderLength);
             dataOffset += secHeaderLength;

--- a/yamcs-core/src/test/java/org/yamcs/tctm/ccsds/TmFrameDecoderTest.java
+++ b/yamcs-core/src/test/java/org/yamcs/tctm/ccsds/TmFrameDecoderTest.java
@@ -47,6 +47,66 @@ public class TmFrameDecoderTest {
         });
     }
 
+    @Test
+    public void testSecHeaderLengthWithVersionNumberBits() throws TcTmException {
+        // CCSDS 132.0-B-3 4.1.3.2.3: the top 2 bits of the first secondary header
+        // byte are the version number and must not leak into the length (issue #1125)
+        TmFrameDecoder tfd = new TmFrameDecoder(getParamsSecHeader());
+
+        // 0x7F: version number 01, length-1 = 63 -> length 64
+        TmTransferFrame tf = tfd.decode(buildFrameWithSecHeader((byte) 0x7F), 0, 128);
+        assertEquals(6, tf.getShStart());
+        assertEquals(64, tf.getShLength());
+        assertEquals(70, tf.getDataStart());
+
+        // 0xBF: version number 10, length-1 = 63 -> length 64
+        tf = tfd.decode(buildFrameWithSecHeader((byte) 0xBF), 0, 128);
+        assertEquals(64, tf.getShLength());
+        assertEquals(70, tf.getDataStart());
+    }
+
+    @Test
+    public void testSecHeaderLengthWithoutVersionNumberBits() throws TcTmException {
+        // 0x09: version number 00, length-1 = 9 -> length 10
+        TmFrameDecoder tfd = new TmFrameDecoder(getParamsSecHeader());
+
+        TmTransferFrame tf = tfd.decode(buildFrameWithSecHeader((byte) 0x09), 0, 128);
+        assertEquals(6, tf.getShStart());
+        assertEquals(10, tf.getShLength());
+        assertEquals(16, tf.getDataStart());
+    }
+
+    byte[] buildFrameWithSecHeader(byte shIdLengthByte) {
+        byte[] data = new byte[128];
+        data[0] = 0x2F; // version 0, spacecraft id 758
+        data[1] = 0x60; // vcId 0, no OCF
+        data[4] = (byte) 0x87; // secondary header present, sync flag 0
+        data[5] = (byte) 0xFF; // first header pointer 0x7FF (no packet starting in this frame)
+        data[6] = shIdLengthByte;
+        return data;
+    }
+
+    TmManagedParameters getParamsSecHeader() {
+        Map<String, Object> m = new HashMap<>();
+        m.put("spacecraftId", 758);
+        m.put("frameLength", 128);
+        m.put("errorDetection", "NONE");
+
+        List<Map<String, Object>> vclist = new ArrayList<>();
+        m.put("virtualChannels", vclist);
+
+        Map<String, Object> vc0 = new HashMap<>();
+        vc0.put("vcId", 0);
+        vc0.put("ocfPresent", false);
+        vc0.put("service", "PACKET");
+        vc0.put("packetPreprocessorClassName", "org.yamcs.tctm.GenericPacketPreprocessor");
+
+        vclist.add(vc0);
+
+        YConfiguration config = YConfiguration.wrap(m);
+        return new TmManagedParameters(config, null, null);
+    }
+
     TmManagedParameters getParams() {
         Map<String, Object> m = new HashMap<>();
         m.put("spacecraftId", 35);


### PR DESCRIPTION
Fixes #1125.

In TmFrameDecoder, the secondary header length is computed as 1 + data[dataOffset] & 0x3F. In Java + binds tighter than &, so this parses as (1 + data[dataOffset]) & 0x3F rather than the intended 1 + (data[dataOffset] & 0x3F). Per CCSDS 132.0-B-3 section 4.1.3.2.3, the low 6 bits of the first secondary header byte encode length minus one and the top two bits are the secondary header version number. When those version-number bits are set, the current expression corrupts the decoded length and the data field start is misplaced, desyncing the rest of the frame.

For example a first byte of 0x7F (version number 01, length field 63) should yield length 64, but the current code yields (1 + 0x7F) & 0x3F = 0. The fix parenthesizes the mask.

Added two tests to TmFrameDecoderTest: one with the version-number bits set (0x7F and 0xBF both decode to length 64) which fails on the current code, and one with an in-range byte (0x09 decodes to length 10) confirming the common case is unchanged. A repo-wide check found no other instances of this pattern; UslpFrameDecoder already parenthesizes correctly.